### PR TITLE
Update devcontainer setup and .gitignore

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -10,6 +10,8 @@ sudo apt install gh
 
 # Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+cargo install cargo-binstall 
+cargo binstall just --no-confirm
 
 # Node.js (Volta)
 curl https://get.volta.sh | bash

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # NodeJS
 node_modules/
+.pnpm-store/
 
 # Rust
 target/


### PR DESCRIPTION
Enhance the setup script to install `cargo-binstall` and `just`, while also adding `.pnpm-store` to the `.gitignore` file.