### PR TITLE
Update elmethis-notion and @elmethis/core to latest alpha versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elmethis-notion"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026c1378ecb2c5b5c94f87e92be4bce7961caeeb075b669419ef22bb33978ee"
+checksum = "b9d7ae115d828f1dc07fb29c2ddddc2d2fd7825335fd46451d673d248e3f1c20"
 dependencies = [
  "async-recursion",
  "dotenvy",

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -21,7 +21,7 @@ reqwest = { version = "0.12.12", features = [
 async-graphql = "7.0.15"
 chrono = "0.4.39"
 dotenvy = "0.15.7"
-elmethis-notion = { version = "1.0.0-alpha.7", features = ["rustls-tls"] }
+elmethis-notion = { version = "1.0.0-alpha.8", features = ["rustls-tls"] }
 lambda_http = "0.14.0"
 notionrs = { version = "1.0.0-alpha.30", features = ["rustls-tls"] }
 serde = { version = "1.0.217", features = ["derive"] }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@aws-sdk/client-ssm": "^3.741.0",
     "@com.46ki75/graphql": "^0.2.2",
-    "@elmethis/core": "1.0.0-alpha.138",
+    "@elmethis/core": "1.0.0-alpha.140",
     "@pinia/nuxt": "0.9.0",
     "@vueuse/core": "^12.5.0",
     "aws-amplify": "^6.12.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       '@elmethis/core':
-        specifier: 1.0.0-alpha.138
-        version: 1.0.0-alpha.138
+        specifier: 1.0.0-alpha.140
+        version: 1.0.0-alpha.140
       '@pinia/nuxt':
         specifier: 0.9.0
         version: 0.9.0(magicast@0.3.5)(pinia@2.3.1(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)))(rollup@4.34.0)
@@ -829,8 +829,8 @@ packages:
     peerDependencies:
       postcss: ^8.4
 
-  '@elmethis/core@1.0.0-alpha.138':
-    resolution: {integrity: sha512-UGe4WVcKhfcVKa3HcotKEnwBWcx8h0eypb5JBDtr/LmbtJ6MSSnSBhC/kGvip9Rk0C5oSGC00VhRjUvo3HQi2g==}
+  '@elmethis/core@1.0.0-alpha.140':
+    resolution: {integrity: sha512-ZYZgsnioaTtpRGT9UezgaVRo8PNRdxAnBAV6+IBGhD18YXPjFYoga56/Y3Yq3Z+p0DhroghetA49ten0s4BrpQ==}
 
   '@esbuild/aix-ppc64@0.24.2':
     resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
@@ -6110,7 +6110,7 @@ snapshots:
     dependencies:
       postcss: 8.5.1
 
-  '@elmethis/core@1.0.0-alpha.138':
+  '@elmethis/core@1.0.0-alpha.140':
     dependencies:
       mermaid: 11.4.1
       nanoid: 5.0.9


### PR DESCRIPTION
Upgrade `elmethis-notion` to version 1.0.0-alpha.8 and `@elmethis/core` to version 1.0.0-alpha.140 to incorporate the latest features and improvements.