### PR TITLE
Add accessToken to typing request

### DIFF
--- a/packages/web/repository/TypingRepository.ts
+++ b/packages/web/repository/TypingRepository.ts
@@ -1,7 +1,7 @@
 import type { TypingEntity } from "~/entity/Entity";
 
 export interface TypingRepository {
-  list(): Promise<TypingEntity[]>;
+  list({ accessToken }: { accessToken: string }): Promise<TypingEntity[]>;
   upsert({
     accessToken,
     text,
@@ -14,13 +14,18 @@ export interface TypingRepository {
 }
 
 export class TypingRepositoryImpl implements TypingRepository {
-  async list(): Promise<TypingEntity[]> {
+  async list({
+    accessToken,
+  }: {
+    accessToken: string;
+  }): Promise<TypingEntity[]> {
     const response = await $fetch<{ data: { typingList: TypingEntity[] } }>(
       "/api/graphql",
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          Authorization: accessToken,
         },
         body: JSON.stringify({
           query: /* GraphQL */ `

--- a/packages/web/stores/TypingStore.ts
+++ b/packages/web/stores/TypingStore.ts
@@ -35,7 +35,9 @@ export const useTypingStore = defineStore("typing", {
       await authStore.refreshIfNeed();
 
       try {
-        const response = await typingRepository.list();
+        const response = await typingRepository.list({
+          accessToken: `${authStore.session.accessToken}`,
+        });
 
         this.typingList = response;
       } catch (error) {


### PR DESCRIPTION
Enhance the `list` method in the `TypingRepository` to require an `accessToken` for authorization, ensuring secure access to the typing data.