### PR TITLE
Refactor tooltips in Header component and update dependencies

### DIFF
--- a/packages/web/components/Header.vue
+++ b/packages/web/components/Header.vue
@@ -1,51 +1,29 @@
 <template>
   <header class="header">
     <div>
-      <ElmTooltip>
-        <template #original>
-          <NuxtLink to="/">
-            <Icon icon="material-symbols:cottage" class="icon" />
-          </NuxtLink>
-        </template>
+      <ElmSimpleTooltip text="Home">
+        <NuxtLink to="/">
+          <Icon icon="material-symbols:cottage" class="icon" />
+        </NuxtLink>
+      </ElmSimpleTooltip>
 
-        <template #tooltip>
-          <span>HOME</span>
-        </template>
-      </ElmTooltip>
+      <ElmSimpleTooltip text="Anki">
+        <NuxtLink to="/anki">
+          <Icon icon="mdi:tag" class="icon" />
+        </NuxtLink>
+      </ElmSimpleTooltip>
 
-      <ElmTooltip>
-        <template #original>
-          <NuxtLink to="/anki"><Icon icon="mdi:tag" class="icon" /></NuxtLink>
-        </template>
+      <ElmSimpleTooltip text="Swatch">
+        <NuxtLink to="/color">
+          <Icon icon="mdi:color" class="icon" />
+        </NuxtLink>
+      </ElmSimpleTooltip>
 
-        <template #tooltip>
-          <span>anki</span>
-        </template>
-      </ElmTooltip>
-
-      <ElmTooltip>
-        <template #original>
-          <NuxtLink to="/color">
-            <Icon icon="mdi:color" class="icon" />
-          </NuxtLink>
-        </template>
-
-        <template #tooltip>
-          <span>Color</span>
-        </template>
-      </ElmTooltip>
-
-      <ElmTooltip>
-        <template #original>
-          <NuxtLink to="/typing">
-            <Icon icon="material-symbols:keyboard" class="icon" />
-          </NuxtLink>
-        </template>
-
-        <template #tooltip>
-          <span>Typing</span>
-        </template>
-      </ElmTooltip>
+      <ElmSimpleTooltip text="Typing">
+        <NuxtLink to="/typing">
+          <Icon icon="material-symbols:keyboard" class="icon" />
+        </NuxtLink>
+      </ElmSimpleTooltip>
     </div>
 
     <div>
@@ -62,7 +40,7 @@
 </template>
 
 <script setup lang="ts">
-import { ElmLoginIcon, ElmToggleTheme, ElmTooltip } from "@elmethis/core";
+import { ElmLoginIcon, ElmToggleTheme, ElmSimpleTooltip } from "@elmethis/core";
 import { Icon } from "@iconify/vue";
 
 const router = useRouter();

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@aws-sdk/client-ssm": "^3.804.0",
     "@com.46ki75/graphql": "^0.2.2",
-    "@elmethis/core": "0.1.2",
+    "@elmethis/core": "0.1.8",
     "@pinia/nuxt": "0.11.0",
     "@vueuse/core": "^13.1.0",
     "aws-amplify": "^6.14.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       '@elmethis/core':
-        specifier: 0.1.2
-        version: 0.1.2(vue@3.5.13(typescript@5.8.3))
+        specifier: 0.1.8
+        version: 0.1.8(vue@3.5.13(typescript@5.8.3))
       '@pinia/nuxt':
         specifier: 0.11.0
         version: 0.11.0(magicast@0.3.5)(pinia@3.0.2(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3)))
@@ -794,8 +794,8 @@ packages:
     resolution: {integrity: sha512-KrkT6qO5NxqNfy68sBl6CTSoJ4SNDIS5iQArkibhlbGU4LaDukZ3q2HIkh8aUKDio6o4itU4xDR7t82Y2eP1Bg==}
     engines: {node: '>=14'}
 
-  '@elmethis/core@0.1.2':
-    resolution: {integrity: sha512-Wu7ZNyaT+FKW63BXu3g3DnyqD2Ews2c1dUAA+q1DKq0UuXRjTz/BSUAPOKaPhFjbNSZ0cKDvJs0JXBnhSC1slg==}
+  '@elmethis/core@0.1.8':
+    resolution: {integrity: sha512-cCSHEAc1hTRgWtsDDUkq/5nDILK7rZylb78s8tD9XSc1/wQV5EpmuUsyCejNAjZdG1m0WOyJmIuRFz+74lg71Q==}
     peerDependencies:
       vue: ^3.4.0
 
@@ -6629,7 +6629,7 @@ snapshots:
       gonzales-pe: 4.3.0
       node-source-walk: 6.0.2
 
-  '@elmethis/core@0.1.2(vue@3.5.13(typescript@5.8.3))':
+  '@elmethis/core@0.1.8(vue@3.5.13(typescript@5.8.3))':
     dependencies:
       '@mdi/js': 7.4.47
       '@vueuse/core': 13.1.0(vue@3.5.13(typescript@5.8.3))


### PR DESCRIPTION
Replace `ElmTooltip` with `ElmSimpleTooltip` for better tooltip handling in the Header component. Update `@elmethis/core` dependency to version 0.1.8.