### PR TITLE
test+ci: Rust unit tests, workspace CI, and coverage

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -47,3 +47,42 @@ jobs:
 
       - name: just ci
         run: just ci
+
+  # Report-only: surfaces hermetic-test coverage but never gates the merge
+  # (coverage is a guardrail, not a target).
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install pinned Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+
+      # cargo-llvm-cov needs the instrumentation tools; rust-toolchain.toml
+      # uses the minimal profile, so add the component explicitly.
+      - name: Add llvm-tools
+        run: rustup component add llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,cargo-llvm-cov
+
+      - name: Generate coverage
+        run: just coverage-ci
+
+      - name: Write coverage summary
+        run: |
+          {
+            echo '### Coverage (hermetic tests)'
+            echo '```'
+            cargo llvm-cov report --summary-only
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload lcov.info
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov
+          path: lcov.info

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -86,3 +86,12 @@ jobs:
         with:
           name: lcov
           path: lcov.info
+
+      # Activates once CODECOV_TOKEN is set in repo secrets; until then it
+      # no-ops without failing the job (fail_ci_if_error: false).
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,49 @@
+name: Rust CI
+
+# Hermetic PR gate: formatting, clippy (-D warnings), and the hermetic test
+# tier. Live tests are `#[ignore]`'d and run only via rust-live.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "Justfile"
+      - ".github/workflows/rust-ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "Justfile"
+      - ".github/workflows/rust-ci.yml"
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: rust-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Installs the toolchain + components (rustfmt, clippy) pinned in
+      # rust-toolchain.toml, so CI runs against the declared version.
+      - name: Install pinned Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: just ci
+        run: just ci

--- a/.github/workflows/rust-live.yml
+++ b/.github/workflows/rust-live.yml
@@ -1,0 +1,31 @@
+name: Rust CI (live)
+
+# Manual-dispatch only. Runs the hermetic gate plus the live tests
+# (`-- --ignored`), which hit AWS (SSM) and the network. Live-test failures
+# are unrelated to any single diff, so this MUST NOT gate PR merges.
+#
+# Setup required before this can pass:
+#   - A `live` environment with required reviewers (the approval gate).
+#   - AWS credentials available to the job (OIDC role or environment secrets).
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ci-live:
+    runs-on: ubuntu-latest
+    environment: live
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install pinned Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: just ci-live
+        run: just ci-live

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 
 # Rust
 target/
+lcov.info

--- a/Justfile
+++ b/Justfile
@@ -17,6 +17,22 @@ test:
 test-live:
     cargo test --workspace -- --ignored
 
+# Instrumented hermetic run (no report emitted yet).
+test-cov:
+    cargo llvm-cov --no-report --workspace
+
+# Per-file table (drops 100%-covered files) + uncovered line numbers.
+coverage: test-cov
+    cargo llvm-cov report --show-missing-lines --color=always 2>&1 | grep -v " 100.00%"
+
+# Local HTML drilldown.
+coverage-html: test-cov
+    cargo llvm-cov report --html --open
+
+# CI: emit lcov.info for upload/inspection.
+coverage-ci: test-cov
+    cargo llvm-cov report --lcov --output-path lcov.info
+
 # Full PR gate.
 ci: fmt-check lint test
 

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,24 @@
+# Workspace-wide Rust recipes. Per-crate recipes (dev/build/deploy/coverage)
+# live in each crate's own Justfile, e.g. crates/http_api/Justfile.
+
+# Reject unformatted code (CI gate).
+fmt-check:
+    cargo fmt --all -- --check
+
+# Deny all clippy warnings across every crate and target (CI gate).
+lint:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Hermetic tests only — live tests are `#[ignore]`'d and skipped here.
+test:
+    cargo test --workspace
+
+# Live / approval-required tests (network + AWS credentials). Not a PR gate.
+test-live:
+    cargo test --workspace -- --ignored
+
+# Full PR gate.
+ci: fmt-check lint test
+
+# Gate plus live tests, for manual dispatch behind an approval environment.
+ci-live: fmt-check lint test test-live

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Coverage is a guardrail, not a merge gate: keep all status checks
+# informational so they never fail a PR. Flip `informational` to false (and
+# optionally set a `target`/`threshold`) once you want coverage to block.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, files"
+  require_changes: false

--- a/crates/feed/src/lib.rs
+++ b/crates/feed/src/lib.rs
@@ -1,3 +1,7 @@
 pub mod error;
 pub mod repository;
 pub mod use_case;
+
+/// Boxed `Send + Sync` future — the dyn-compatible return shape shared by the
+/// async methods on [`repository::Repository`] and [`use_case::UseCase`].
+pub type BoxFuture<T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + Sync>>;

--- a/crates/feed/src/repository.rs
+++ b/crates/feed/src/repository.rs
@@ -1,34 +1,15 @@
-use std::pin::Pin;
-
+use crate::BoxFuture;
 use reqwest::header::USER_AGENT;
 
 pub trait Repository {
-    fn fetch_html(
-        &self,
-        url: &str,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<Output = Result<String, Box<dyn std::error::Error>>>
-                + Send
-                + Sync,
-        >,
-    >;
+    fn fetch_html(&self, url: &str) -> BoxFuture<Result<String, Box<dyn std::error::Error>>>;
 }
 
 #[derive(Debug)]
 pub struct RepositoryImpl {}
 
 impl Repository for RepositoryImpl {
-    fn fetch_html(
-        &self,
-        url: &str,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<Output = Result<String, Box<dyn std::error::Error>>>
-                + Send
-                + Sync,
-        >,
-    > {
+    fn fetch_html(&self, url: &str) -> BoxFuture<Result<String, Box<dyn std::error::Error>>> {
         let url = url.to_owned();
 
         Box::pin(async move {

--- a/crates/feed/src/use_case.rs
+++ b/crates/feed/src/use_case.rs
@@ -1,18 +1,10 @@
-use std::{pin::Pin, sync::Arc};
+use crate::BoxFuture;
+use std::sync::Arc;
 
 pub trait UseCase {
     fn to_markdown(&self, html: &str) -> String;
 
-    fn fetch_html(
-        &self,
-        url: &str,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<Output = Result<String, Box<dyn std::error::Error>>>
-                + Send
-                + Sync,
-        >,
-    >;
+    fn fetch_html(&self, url: &str) -> BoxFuture<Result<String, Box<dyn std::error::Error>>>;
 
     fn parse_feed(&self, text: &str) -> Result<feed_rs::model::Feed, Box<dyn std::error::Error>> {
         let feed = feed_rs::parser::parse(text.as_bytes())?;
@@ -29,16 +21,7 @@ impl UseCase for UseCaseImpl {
         html2md::rewrite_html(html, false)
     }
 
-    fn fetch_html(
-        &self,
-        url: &str,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<Output = Result<String, Box<dyn std::error::Error>>>
-                + Send
-                + Sync,
-        >,
-    > {
+    fn fetch_html(&self, url: &str) -> BoxFuture<Result<String, Box<dyn std::error::Error>>> {
         self.repository.fetch_html(url)
     }
 

--- a/crates/feed/tests/fetch_aws.rs
+++ b/crates/feed/tests/fetch_aws.rs
@@ -2,7 +2,8 @@ use feed::use_case::UseCase;
 use std::sync::Arc;
 
 #[tokio::test]
-async fn fetch_aws() {
+#[ignore = "live: fetches a real AWS web page over the network"]
+async fn live_fetch_aws() {
     let repository = feed::repository::RepositoryImpl {};
     let use_case = feed::use_case::UseCaseImpl {
         repository: Arc::new(repository),
@@ -22,7 +23,8 @@ async fn fetch_aws() {
 }
 
 #[tokio::test]
-async fn parse_feed() {
+#[ignore = "live: fetches a real RSS feed over the network"]
+async fn live_parse_feed() {
     let repository = feed::repository::RepositoryImpl {};
     let use_case = feed::use_case::UseCaseImpl {
         repository: Arc::new(repository),

--- a/crates/http_api/Justfile
+++ b/crates/http_api/Justfile
@@ -8,4 +8,20 @@ deploy  STAGE_NAME: build
     cargo lambda deploy --binary-name http-api "{{STAGE_NAME}}-46ki75-internal-lambda-function-http-api"
 
 test:
-    cargo test --lib
+    cargo test -p http-api --lib
+
+# Instrumented hermetic run (no report yet)
+test-cov:
+    cargo llvm-cov --no-report -p http-api --lib
+
+# AI-friendly per-file table (drops 100%-covered files) + uncovered line numbers
+coverage: test-cov
+    cargo llvm-cov report --show-missing-lines --color=always 2>&1 | grep -v " 100.00%"
+
+# Local HTML drilldown
+coverage-html: test-cov
+    cargo llvm-cov report --html --open
+
+# CI / Codecov upload
+coverage-ci: test-cov
+    cargo llvm-cov report --lcov --output-path lcov.info

--- a/crates/http_api/src/anki/use_case/mod.rs
+++ b/crates/http_api/src/anki/use_case/mod.rs
@@ -80,41 +80,41 @@ fn partition_blocks_by_section(
     let mut explanation: Vec<String> = Vec::new();
 
     for child_id in root_children {
-        if let Some(Component::Heading(heading)) = surface.components.get(&child_id) {
-            if matches!(heading.level, HeadingLevel::H1) {
-                let heading_ids = match &heading.children {
-                    ChildList::Static(ids) => ids.as_slice(),
-                    ChildList::Template(_) => &[],
-                };
+        if let Some(Component::Heading(heading)) = surface.components.get(&child_id)
+            && matches!(heading.level, HeadingLevel::H1)
+        {
+            let heading_ids = match &heading.children {
+                ChildList::Static(ids) => ids.as_slice(),
+                ChildList::Template(_) => &[],
+            };
 
-                let text = heading_ids
-                    .iter()
-                    .filter_map(|id| match surface.components.get(id) {
-                        Some(Component::RichText(rt)) => match &rt.text {
-                            DynamicString::Literal(s) => Some(s.as_str()),
-                            _ => None,
-                        },
+            let text = heading_ids
+                .iter()
+                .filter_map(|id| match surface.components.get(id) {
+                    Some(Component::RichText(rt)) => match &rt.text {
+                        DynamicString::Literal(s) => Some(s.as_str()),
                         _ => None,
-                    })
-                    .collect::<String>()
-                    .trim()
-                    .to_lowercase();
+                    },
+                    _ => None,
+                })
+                .collect::<String>()
+                .trim()
+                .to_lowercase();
 
-                match text.as_str() {
-                    "front" => {
-                        marker = Marker::Front;
-                        continue;
-                    }
-                    "back" => {
-                        marker = Marker::Back;
-                        continue;
-                    }
-                    "explanation" => {
-                        marker = Marker::Explanation;
-                        continue;
-                    }
-                    _ => {}
+            match text.as_str() {
+                "front" => {
+                    marker = Marker::Front;
+                    continue;
                 }
+                "back" => {
+                    marker = Marker::Back;
+                    continue;
+                }
+                "explanation" => {
+                    marker = Marker::Explanation;
+                    continue;
+                }
+                _ => {}
             }
         }
 

--- a/crates/http_api/src/anki/use_case/mod.rs
+++ b/crates/http_api/src/anki/use_case/mod.rs
@@ -49,6 +49,85 @@ fn build_section_surface(
     }
 }
 
+/// Walks a surface's root children and partitions their ids into the
+/// `(front, back, explanation)` sections, switching buckets on H1 headings
+/// whose text is exactly "front", "back", or "explanation" (case-insensitive,
+/// trimmed). The marker headings themselves are dropped; every other block —
+/// including non-H1 or unrecognized headings — is kept as content in the
+/// current section. Blocks before the first marker default to `front`.
+fn partition_blocks_by_section(
+    surface: &n2a2ui_a2ui::v0_9::Surface,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    use n2a2ui_a2ui::v0_9::{ChildList, Component, DynamicString, HeadingLevel};
+
+    let root_children: Vec<String> = match surface.components.get(&surface.root) {
+        Some(Component::Column(column)) => match &column.children {
+            ChildList::Static(ids) => ids.clone(),
+            ChildList::Template(_) => Vec::new(),
+        },
+        _ => Vec::new(),
+    };
+
+    enum Marker {
+        Front,
+        Back,
+        Explanation,
+    }
+
+    let mut marker = Marker::Front;
+    let mut front: Vec<String> = Vec::new();
+    let mut back: Vec<String> = Vec::new();
+    let mut explanation: Vec<String> = Vec::new();
+
+    for child_id in root_children {
+        if let Some(Component::Heading(heading)) = surface.components.get(&child_id) {
+            if matches!(heading.level, HeadingLevel::H1) {
+                let heading_ids = match &heading.children {
+                    ChildList::Static(ids) => ids.as_slice(),
+                    ChildList::Template(_) => &[],
+                };
+
+                let text = heading_ids
+                    .iter()
+                    .filter_map(|id| match surface.components.get(id) {
+                        Some(Component::RichText(rt)) => match &rt.text {
+                            DynamicString::Literal(s) => Some(s.as_str()),
+                            _ => None,
+                        },
+                        _ => None,
+                    })
+                    .collect::<String>()
+                    .trim()
+                    .to_lowercase();
+
+                match text.as_str() {
+                    "front" => {
+                        marker = Marker::Front;
+                        continue;
+                    }
+                    "back" => {
+                        marker = Marker::Back;
+                        continue;
+                    }
+                    "explanation" => {
+                        marker = Marker::Explanation;
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        match marker {
+            Marker::Front => front.push(child_id),
+            Marker::Back => back.push(child_id),
+            Marker::Explanation => explanation.push(child_id),
+        }
+    }
+
+    (front, back, explanation)
+}
+
 impl AnkiUseCase {
     pub async fn get_anki_by_id(&self, id: &str) -> Result<AnkiEntity, AnkiUseCaseError> {
         let page = self.anki_repository.get_anki_by_id(id).await?;
@@ -80,74 +159,9 @@ impl AnkiUseCase {
     }
 
     pub async fn list_blocks(&self, id: &str) -> Result<AnkiBlockEntity, AnkiUseCaseError> {
-        use n2a2ui_a2ui::v0_9::{ChildList, Component, DynamicString, HeadingLevel};
-
         let surface = self.anki_repository.list_blocks_by_id(id).await?;
 
-        let root_children: Vec<String> = match surface.components.get(&surface.root) {
-            Some(Component::Column(column)) => match &column.children {
-                ChildList::Static(ids) => ids.clone(),
-                ChildList::Template(_) => Vec::new(),
-            },
-            _ => Vec::new(),
-        };
-
-        enum Marker {
-            Front,
-            Back,
-            Explanation,
-        }
-
-        let mut marker = Marker::Front;
-        let mut front: Vec<String> = Vec::new();
-        let mut back: Vec<String> = Vec::new();
-        let mut explanation: Vec<String> = Vec::new();
-
-        for child_id in root_children {
-            if let Some(Component::Heading(heading)) = surface.components.get(&child_id) {
-                if matches!(heading.level, HeadingLevel::H1) {
-                    let heading_ids = match &heading.children {
-                        ChildList::Static(ids) => ids.as_slice(),
-                        ChildList::Template(_) => &[],
-                    };
-
-                    let text = heading_ids
-                        .iter()
-                        .filter_map(|id| match surface.components.get(id) {
-                            Some(Component::RichText(rt)) => match &rt.text {
-                                DynamicString::Literal(s) => Some(s.as_str()),
-                                _ => None,
-                            },
-                            _ => None,
-                        })
-                        .collect::<String>()
-                        .trim()
-                        .to_lowercase();
-
-                    match text.as_str() {
-                        "front" => {
-                            marker = Marker::Front;
-                            continue;
-                        }
-                        "back" => {
-                            marker = Marker::Back;
-                            continue;
-                        }
-                        "explanation" => {
-                            marker = Marker::Explanation;
-                            continue;
-                        }
-                        _ => {}
-                    }
-                }
-            }
-
-            match marker {
-                Marker::Front => front.push(child_id),
-                Marker::Back => back.push(child_id),
-                Marker::Explanation => explanation.push(child_id),
-            }
-        }
+        let (front, back, explanation) = partition_blocks_by_section(&surface);
 
         let front_surface = build_section_surface(&surface, front);
         let back_surface = build_section_surface(&surface, back);
@@ -303,41 +317,303 @@ impl AnkiUseCase {
 mod tests {
     use super::*;
     use crate::anki::repository::AnkiRepositoryStub;
+    use n2a2ui_a2ui::v0_9::{
+        ChildList, Column, Component, DynamicString, Heading, HeadingLevel, RichText, Surface,
+    };
 
-    #[tokio::test]
-    async fn separate_blocks() {
-        let anki_repository_stub = std::sync::Arc::new(AnkiRepositoryStub);
-        let anki_use_case = AnkiUseCase {
-            anki_repository: anki_repository_stub,
+    // ---- test-surface builders ----
+
+    /// An H1 heading whose visible text is `text`, plus the inner RichText that
+    /// carries it. Returns both components; the heading id is `id`.
+    fn marker(id: &str, text: &str) -> Vec<(String, Component)> {
+        let txt_id = format!("{id}-txt");
+        vec![
+            (
+                id.to_string(),
+                Component::Heading(Heading {
+                    id: id.to_string(),
+                    level: HeadingLevel::H1,
+                    children: ChildList::Static(vec![txt_id.clone()]),
+                    ..Default::default()
+                }),
+            ),
+            (
+                txt_id.clone(),
+                Component::RichText(RichText {
+                    id: txt_id,
+                    text: DynamicString::Literal(text.to_string()),
+                    ..Default::default()
+                }),
+            ),
+        ]
+    }
+
+    /// An H1 heading whose text is NOT a section marker (e.g. "notes").
+    fn heading_with_level(id: &str, level: HeadingLevel, text: &str) -> Vec<(String, Component)> {
+        let txt_id = format!("{id}-txt");
+        vec![
+            (
+                id.to_string(),
+                Component::Heading(Heading {
+                    id: id.to_string(),
+                    level,
+                    children: ChildList::Static(vec![txt_id.clone()]),
+                    ..Default::default()
+                }),
+            ),
+            (
+                txt_id.clone(),
+                Component::RichText(RichText {
+                    id: txt_id,
+                    text: DynamicString::Literal(text.to_string()),
+                    ..Default::default()
+                }),
+            ),
+        ]
+    }
+
+    /// A plain content block (a RichText not nested under any heading).
+    fn content(id: &str) -> (String, Component) {
+        (
+            id.to_string(),
+            Component::RichText(RichText {
+                id: id.to_string(),
+                text: DynamicString::Literal(format!("content-{id}")),
+                ..Default::default()
+            }),
+        )
+    }
+
+    fn build_surface(root_children: &[&str], comps: Vec<(String, Component)>) -> Surface {
+        let mut components = indexmap::IndexMap::new();
+        components.insert(
+            "root".to_string(),
+            Component::Column(Column {
+                id: "root".to_string(),
+                children: ChildList::Static(root_children.iter().map(|s| s.to_string()).collect()),
+                ..Default::default()
+            }),
+        );
+        for (id, c) in comps {
+            components.insert(id, c);
+        }
+        Surface {
+            root: "root".to_string(),
+            components,
+        }
+    }
+
+    // ---- partition_blocks_by_section (pure) ----
+
+    #[test]
+    fn partition_three_sections() {
+        let mut comps = Vec::new();
+        comps.extend(marker("hf", "front"));
+        comps.push(content("c1"));
+        comps.extend(marker("hb", "back"));
+        comps.push(content("c2"));
+        comps.extend(marker("he", "explanation"));
+        comps.push(content("c3"));
+        let surface = build_surface(&["hf", "c1", "hb", "c2", "he", "c3"], comps);
+
+        let (front, back, explanation) = partition_blocks_by_section(&surface);
+
+        assert_eq!(front, vec!["c1"]);
+        assert_eq!(back, vec!["c2"]);
+        assert_eq!(explanation, vec!["c3"]);
+    }
+
+    #[test]
+    fn partition_marker_text_is_case_insensitive_and_trimmed() {
+        let mut comps = Vec::new();
+        comps.extend(marker("hf", "  Front  "));
+        comps.push(content("c1"));
+        comps.extend(marker("hb", "BACK"));
+        comps.push(content("c2"));
+        let surface = build_surface(&["hf", "c1", "hb", "c2"], comps);
+
+        let (front, back, explanation) = partition_blocks_by_section(&surface);
+
+        assert_eq!(front, vec!["c1"]);
+        assert_eq!(back, vec!["c2"]);
+        assert!(explanation.is_empty());
+    }
+
+    #[test]
+    fn partition_blocks_before_first_marker_default_to_front() {
+        let mut comps = Vec::new();
+        comps.push(content("c0"));
+        comps.extend(marker("hb", "back"));
+        comps.push(content("c1"));
+        let surface = build_surface(&["c0", "hb", "c1"], comps);
+
+        let (front, back, explanation) = partition_blocks_by_section(&surface);
+
+        assert_eq!(front, vec!["c0"]);
+        assert_eq!(back, vec!["c1"]);
+        assert!(explanation.is_empty());
+    }
+
+    #[test]
+    fn partition_unknown_h1_heading_is_kept_as_content() {
+        let mut comps = Vec::new();
+        comps.extend(marker("hb", "back"));
+        comps.extend(heading_with_level("hu", HeadingLevel::H1, "notes"));
+        comps.push(content("c1"));
+        let surface = build_surface(&["hb", "hu", "c1"], comps);
+
+        let (front, back, explanation) = partition_blocks_by_section(&surface);
+
+        // The unrecognized heading id itself stays in the current (back) section.
+        assert_eq!(back, vec!["hu", "c1"]);
+        assert!(front.is_empty());
+        assert!(explanation.is_empty());
+    }
+
+    #[test]
+    fn partition_non_h1_marker_does_not_switch() {
+        // An H2 "front" must not switch the section — only H1 markers do.
+        let mut comps = Vec::new();
+        comps.extend(heading_with_level("h2", HeadingLevel::H2, "front"));
+        comps.push(content("c1"));
+        let surface = build_surface(&["h2", "c1"], comps);
+
+        let (front, back, explanation) = partition_blocks_by_section(&surface);
+
+        // Stays in the default front bucket and keeps the H2 heading as content.
+        assert_eq!(front, vec!["h2", "c1"]);
+        assert!(back.is_empty());
+        assert!(explanation.is_empty());
+    }
+
+    #[test]
+    fn partition_preserves_order_within_section() {
+        let mut comps = Vec::new();
+        comps.extend(marker("hb", "back"));
+        comps.push(content("c1"));
+        comps.push(content("c2"));
+        let surface = build_surface(&["hb", "c1", "c2"], comps);
+
+        let (_, back, _) = partition_blocks_by_section(&surface);
+
+        assert_eq!(back, vec!["c1", "c2"]);
+    }
+
+    #[test]
+    fn partition_empty_root_is_all_empty() {
+        let surface = build_surface(&[], Vec::new());
+        let (front, back, explanation) = partition_blocks_by_section(&surface);
+        assert!(front.is_empty());
+        assert!(back.is_empty());
+        assert!(explanation.is_empty());
+    }
+
+    #[test]
+    fn partition_root_not_a_column_is_all_empty() {
+        let mut components = indexmap::IndexMap::new();
+        components.insert("root".to_string(), content("root").1);
+        let surface = Surface {
+            root: "root".to_string(),
+            components,
         };
 
-        let _ = anki_use_case
+        let (front, back, explanation) = partition_blocks_by_section(&surface);
+        assert!(front.is_empty());
+        assert!(back.is_empty());
+        assert!(explanation.is_empty());
+    }
+
+    // ---- build_section_surface (pure) ----
+
+    #[test]
+    fn build_section_surface_rewrites_root_and_preserves_others() {
+        let source = build_surface(&["a", "b"], vec![content("a"), content("b")]);
+        // Give the source a non-"root" root id to prove the old root is removed.
+        let source = Surface {
+            root: "orig".to_string(),
+            components: {
+                let mut c = source.components;
+                // rename the column under id "orig"
+                let col = c.shift_remove("root").unwrap();
+                c.insert("orig".to_string(), col);
+                c
+            },
+        };
+
+        let result = build_section_surface(&source, vec!["a".to_string()]);
+
+        assert_eq!(result.root, SECTION_ROOT_ID);
+        assert!(result.components.contains_key(SECTION_ROOT_ID));
+        assert!(!result.components.contains_key("orig"));
+        match result.components.get(SECTION_ROOT_ID) {
+            Some(Component::Column(col)) => match &col.children {
+                ChildList::Static(ids) => assert_eq!(ids, &vec!["a".to_string()]),
+                _ => panic!("expected static children"),
+            },
+            _ => panic!("expected a Column at the root id"),
+        }
+        // Non-root content components survive.
+        assert!(result.components.contains_key("a"));
+        assert!(result.components.contains_key("b"));
+    }
+
+    #[test]
+    fn build_section_surface_accepts_empty_children() {
+        let source = build_surface(&["a"], vec![content("a")]);
+        let result = build_section_surface(&source, Vec::new());
+
+        match result.components.get(SECTION_ROOT_ID) {
+            Some(Component::Column(col)) => match &col.children {
+                ChildList::Static(ids) => assert!(ids.is_empty()),
+                _ => panic!("expected static children"),
+            },
+            _ => panic!("expected a Column at the root id"),
+        }
+    }
+
+    // ---- async use-case methods (via stub) ----
+
+    #[tokio::test]
+    async fn list_blocks_returns_three_root_surfaces() {
+        let anki_use_case = AnkiUseCase {
+            anki_repository: std::sync::Arc::new(AnkiRepositoryStub),
+        };
+
+        let blocks = anki_use_case
             .list_blocks("28b8e5f3-ba43-44a8-b790-bfc8c62b7628")
             .await
             .unwrap();
+
+        for section in [&blocks.front, &blocks.back, &blocks.explanation] {
+            assert_eq!(section["root"], "root");
+        }
     }
 
     #[tokio::test]
-    async fn create_anki() {
-        let anki_repository_stub = std::sync::Arc::new(AnkiRepositoryStub);
+    async fn create_anki_maps_stub_response() {
         let anki_use_case = AnkiUseCase {
-            anki_repository: anki_repository_stub,
+            anki_repository: std::sync::Arc::new(AnkiRepositoryStub),
         };
 
-        let _ = anki_use_case
+        let anki = anki_use_case
             .create_anki(Some("title".to_string()))
             .await
             .unwrap();
+
+        assert_eq!(anki.page_id, "4a3720d5-fcdd-46f1-a7b8-51e168ac5e8e");
+        assert_eq!(anki.title.as_deref(), Some("title"));
+        assert_eq!(anki.ease_factor, 2.5);
+        assert_eq!(anki.repetition_count, 5);
+        assert!(!anki.is_review_required);
     }
 
     #[tokio::test]
-    async fn update_anki() {
-        let anki_repository_stub = std::sync::Arc::new(AnkiRepositoryStub);
+    async fn update_anki_maps_stub_response() {
         let anki_use_case = AnkiUseCase {
-            anki_repository: anki_repository_stub,
+            anki_repository: std::sync::Arc::new(AnkiRepositoryStub),
         };
 
-        let _ = anki_use_case
+        let anki = anki_use_case
             .update_anki(
                 "28b8e5f3-ba43-44a8-b790-bfc8c62b7628",
                 Some(2.5),
@@ -348,5 +624,9 @@ mod tests {
             )
             .await
             .unwrap();
+
+        assert_eq!(anki.ease_factor, 2.5);
+        assert_eq!(anki.repetition_count, 5);
+        assert_eq!(anki.title.as_deref(), Some("title"));
     }
 }

--- a/crates/http_api/src/bookmark/resolver/mod.rs
+++ b/crates/http_api/src/bookmark/resolver/mod.rs
@@ -29,7 +29,7 @@ impl From<BookmarkEntity> for Bookmark {
             name: value.name,
             url: value.url,
             favicon: value.favicon,
-            tag: value.tag.map(|tag| BookmarkTag::from(tag)),
+            tag: value.tag.map(BookmarkTag::from),
             nsfw: value.nsfw,
             favorite: value.favorite,
             notion_url: value.notion_url,

--- a/crates/http_api/src/bookmark/resolver/query.rs
+++ b/crates/http_api/src/bookmark/resolver/query.rs
@@ -16,7 +16,7 @@ impl BookmarkQueryResolver {
             .await
             .map_err(|e| e.to_string())?
             .into_iter()
-            .map(|bookmark_entity| super::Bookmark::from(bookmark_entity))
+            .map(super::Bookmark::from)
             .collect::<Vec<super::Bookmark>>();
 
         Ok(bookmarks)

--- a/crates/http_api/src/bookmark/use_case/mod.rs
+++ b/crates/http_api/src/bookmark/use_case/mod.rs
@@ -61,17 +61,23 @@ impl BookmarkUseCase {
 
     async fn fetch_facicon_url(&self, url: &str) -> Option<String> {
         let html = self.bookmark_repository.fetch_html(url).await.ok()?;
-
-        let scraper = html_meta_scraper::MetaScraper::new(&html);
-
-        let favicon = format!("/{}", scraper.favicon()?).replace("//", "/");
-
-        let url = url::Url::parse(url).ok()?;
-
-        let favicon_url = format!("{}://{}{}", url.scheme(), url.host()?, favicon);
-
-        Some(favicon_url)
+        resolve_favicon_url(&html, url)
     }
+}
+
+/// Extracts the favicon href from `html` and resolves it against `page_url`'s
+/// scheme and host into an absolute URL. Returns `None` when the page has no
+/// favicon link, when `page_url` is unparseable, or when it carries no host.
+fn resolve_favicon_url(html: &str, page_url: &str) -> Option<String> {
+    let scraper = html_meta_scraper::MetaScraper::new(html);
+
+    let favicon = format!("/{}", scraper.favicon()?).replace("//", "/");
+
+    let url = url::Url::parse(page_url).ok()?;
+
+    let favicon_url = format!("{}://{}{}", url.scheme(), url.host()?, favicon);
+
+    Some(favicon_url)
 }
 
 #[cfg(test)]
@@ -80,32 +86,78 @@ mod tests {
     use super::*;
     use crate::bookmark::repository::BookmarkRepositoryStub;
 
-    #[tokio::test]
-    async fn list_bookmark() {
-        let bookmark_repository = std::sync::Arc::new(BookmarkRepositoryStub);
+    // ---- resolve_favicon_url (pure) ----
 
+    #[test]
+    fn favicon_relative_href_is_resolved_against_host() {
+        let html = r#"<link rel="icon" href="favicon.ico" />"#;
+        let result = resolve_favicon_url(html, "https://example.com/some/path");
+        assert_eq!(result, Some("https://example.com/favicon.ico".to_string()));
+    }
+
+    #[test]
+    fn favicon_absolute_path_href_collapses_double_slash() {
+        let html = r#"<link rel="icon" href="/static/icon.png" />"#;
+        let result = resolve_favicon_url(html, "https://example.com/some/path");
+        assert_eq!(
+            result,
+            Some("https://example.com/static/icon.png".to_string())
+        );
+    }
+
+    #[test]
+    fn favicon_missing_link_is_none() {
+        let html = r#"<html><head><title>no icon</title></head></html>"#;
+        assert_eq!(resolve_favicon_url(html, "https://example.com"), None);
+    }
+
+    #[test]
+    fn favicon_unparseable_page_url_is_none() {
+        let html = r#"<link rel="icon" href="/favicon.ico" />"#;
+        assert_eq!(resolve_favicon_url(html, "not a url"), None);
+    }
+
+    #[test]
+    fn favicon_hostless_page_url_is_none() {
+        let html = r#"<link rel="icon" href="/favicon.ico" />"#;
+        // `mailto:` parses but exposes no host.
+        assert_eq!(resolve_favicon_url(html, "mailto:a@b.com"), None);
+    }
+
+    // ---- async use-case methods (via stub) ----
+
+    #[tokio::test]
+    async fn list_bookmark_returns_converted_entities() {
         let bookmark_use_case = BookmarkUseCase {
-            bookmark_repository,
+            bookmark_repository: std::sync::Arc::new(BookmarkRepositoryStub),
         };
 
-        let _bookmark = bookmark_use_case
-            .bookmark_repository
-            .list_bookmark()
-            .await
-            .expect("list_bookmark failed");
+        let bookmarks = bookmark_use_case.list_bookmark().await.unwrap();
+
+        assert_eq!(bookmarks.len(), 1);
+        assert_eq!(bookmarks[0].name.as_deref(), Some("三菱UFJダイレクト"));
+        assert_eq!(
+            bookmarks[0].url.as_deref(),
+            Some("https://direct.bk.mufg.jp/index.html")
+        );
     }
 
     #[tokio::test]
-    async fn create_bookmark() {
-        let bookmark_repository = std::sync::Arc::new(BookmarkRepositoryStub);
-
+    async fn create_bookmark_returns_converted_entity() {
         let bookmark_use_case = BookmarkUseCase {
-            bookmark_repository,
+            bookmark_repository: std::sync::Arc::new(BookmarkRepositoryStub),
         };
 
-        let _bookmark = bookmark_use_case
+        let bookmark = bookmark_use_case
             .create_bookmark("name", "https://example.com")
             .await
-            .expect("create_bookmark failed");
+            .unwrap();
+
+        // The stub echoes bookmark.json regardless of the input arguments.
+        assert_eq!(bookmark.name.as_deref(), Some("三菱UFJダイレクト"));
+        assert_eq!(
+            bookmark.url.as_deref(),
+            Some("https://direct.bk.mufg.jp/index.html")
+        );
     }
 }

--- a/crates/http_api/src/error.rs
+++ b/crates/http_api/src/error.rs
@@ -9,9 +9,22 @@ pub enum Error {
     #[error("serde error: {0}")]
     SerdeJson(#[from] serde_json::Error),
 
+    // Boxed: this AWS `SdkError` is ~360 bytes and would otherwise dominate the
+    // size of `Error` — and of every enum that wraps it via `#[from]`.
     #[error("SSM SDK error: {0}")]
     SsmSdkError(
-        #[from]
-        aws_sdk_ssm::error::SdkError<aws_sdk_ssm::operation::get_parameter::GetParameterError>,
+        Box<aws_sdk_ssm::error::SdkError<aws_sdk_ssm::operation::get_parameter::GetParameterError>>,
     ),
+}
+
+impl From<aws_sdk_ssm::error::SdkError<aws_sdk_ssm::operation::get_parameter::GetParameterError>>
+    for Error
+{
+    fn from(
+        value: aws_sdk_ssm::error::SdkError<
+            aws_sdk_ssm::operation::get_parameter::GetParameterError,
+        >,
+    ) -> Self {
+        Error::SsmSdkError(Box::new(value))
+    }
 }

--- a/crates/http_api/src/graphql_handler.rs
+++ b/crates/http_api/src/graphql_handler.rs
@@ -33,25 +33,23 @@ pub async fn graphql_handler(
                 .body(axum::body::Body::from(body));
 
             match response {
-                Ok(r) => return Ok(r),
-                Err(err) => {
-                    return Err((
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        axum::Json::from(
-                            serde_json::json!({"message": format!("Failed to serialize response: {}", err)}),
-                        ),
-                    ));
-                }
+                Ok(r) => Ok(r),
+                Err(err) => Err((
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    axum::Json::from(
+                        serde_json::json!({"message": format!("Failed to serialize response: {}", err)}),
+                    ),
+                )),
             }
         }
         Err(err) => {
             lambda_http::tracing::error!("Failed to serialize response: {}", err);
-            return Err((
+            Err((
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                 axum::Json::from(
                     serde_json::json!({"message": format!("Failed to serialize response: {}", err)}),
                 ),
-            ));
+            ))
         }
-    };
+    }
 }

--- a/crates/http_api/src/layer/auth.rs
+++ b/crates/http_api/src/layer/auth.rs
@@ -3,6 +3,12 @@ use http::StatusCode;
 #[derive(Debug, Clone)]
 pub struct AuthLayer {}
 
+impl Default for AuthLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AuthLayer {
     pub fn new() -> Self {
         Self {}
@@ -33,7 +39,7 @@ impl<S> AuthMiddleware<S> {
     ) -> Result<(), axum::response::Response> {
         let sdk_config = &aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
 
-        let client = aws_sdk_cognitoidentityprovider::Client::new(&sdk_config);
+        let client = aws_sdk_cognitoidentityprovider::Client::new(sdk_config);
 
         let authorization_header_value = Self::extract_authorization_header_value(headers).ok_or(
             axum::response::IntoResponse::into_response((
@@ -51,42 +57,33 @@ impl<S> AuthMiddleware<S> {
 
         let result = client.get_user().access_token(access_token).send().await;
 
-        let user = match result {
+        match result {
             Ok(_user) => Ok(()),
             Err(_) => Err(axum::response::IntoResponse::into_response((
                 StatusCode::UNAUTHORIZED,
                 "Invalid token.",
             ))),
-        };
-
-        user
+        }
     }
 
     fn extract_authorization_header_value(
         headers: &http::HeaderMap<http::HeaderValue>,
     ) -> Option<String> {
-        let value =
-            headers
-                .get(http::header::AUTHORIZATION)
-                .and_then(|authorization_header_value| {
-                    authorization_header_value
-                        .to_str()
-                        .ok()
-                        .map(|s| s.to_owned())
-                });
-
-        value
+        headers
+            .get(http::header::AUTHORIZATION)
+            .and_then(|authorization_header_value| {
+                authorization_header_value
+                    .to_str()
+                    .ok()
+                    .map(|s| s.to_owned())
+            })
     }
 
     fn normalize_bearer_token(autorization_header_value: String) -> Option<String> {
         let re: regex::Regex = regex::Regex::new(r"^(?:Bearer\s+)?([A-Za-z0-9\-_\.=]+)$").unwrap();
 
-        let token = re.captures(&autorization_header_value).and_then(|t| {
-            let first = t.get(1).map(|m| m.as_str().to_string());
-            first
-        });
-
-        token
+        re.captures(&autorization_header_value)
+            .and_then(|t| t.get(1).map(|m| m.as_str().to_string()))
     }
 }
 

--- a/crates/http_api/src/to_do/use_case/mod.rs
+++ b/crates/http_api/src/to_do/use_case/mod.rs
@@ -17,109 +17,111 @@ pub struct ToDoUseCase {
     pub to_do_repository: std::sync::Arc<dyn ToDoRepository + Send + Sync>,
 }
 
-impl ToDoUseCase {
-    fn convert_page_response_to_to_do_entity(
-        &self,
-        response: &PageResponse,
-    ) -> Result<ToDoEntity, ToDoUseCaseError> {
-        let id = response.id.clone();
+fn convert_page_response_to_to_do_entity(
+    response: &PageResponse,
+) -> Result<ToDoEntity, ToDoUseCaseError> {
+    let id = response.id.clone();
 
-        let url = response.url.clone();
+    let url = response.url.clone();
 
-        let source = String::from("Notion:todo");
+    let source = String::from("Notion:todo");
 
-        let title = response
+    let title = response
+        .properties
+        .get("Title")
+        .ok_or(ToDoUseCaseError::PropertyNotFound("title".to_string()))?
+        .to_string();
+
+    let description = response.properties.get("Description").and_then(|d| {
+        let description = d.to_string();
+        if description.trim().is_empty() {
+            None
+        } else {
+            Some(description)
+        }
+    });
+
+    let is_done = match response
+        .properties
+        .get("IsDone")
+        .ok_or(ToDoUseCaseError::PropertyNotFound("IsDone".to_string()))?
+    {
+        PageProperty::Checkbox(is_done) => Ok(is_done.checkbox),
+        _ => Err(ToDoUseCaseError::PropertyNotFound("IsDone".to_string())),
+    }?;
+
+    let is_recurring =
+        match response
             .properties
-            .get("Title")
-            .ok_or(ToDoUseCaseError::PropertyNotFound("title".to_string()))?
-            .to_string();
-
-        let description = response.properties.get("Description").and_then(|d| {
-            let description = d.to_string();
-            if description.trim().is_empty() {
-                None
-            } else {
-                Some(description)
-            }
-        });
-
-        let is_done = match response
-            .properties
-            .get("IsDone")
-            .ok_or(ToDoUseCaseError::PropertyNotFound("IsDone".to_string()))?
-        {
-            PageProperty::Checkbox(is_done) => Ok(is_done.checkbox),
-            _ => Err(ToDoUseCaseError::PropertyNotFound("IsDone".to_string())),
-        }?;
-
-        let is_recurring = match response.properties.get("IsRecurring").ok_or(
-            ToDoUseCaseError::PropertyNotFound("IsRecurring".to_string()),
-        )? {
+            .get("IsRecurring")
+            .ok_or(ToDoUseCaseError::PropertyNotFound(
+                "IsRecurring".to_string(),
+            ))? {
             PageProperty::Checkbox(is_done) => Ok(is_done.checkbox),
             _ => Err(ToDoUseCaseError::PropertyNotFound(
                 "IsRecurring".to_string(),
             )),
         }?;
 
-        let is_archived = match response
-            .properties
-            .get("IsArchived")
-            .ok_or(ToDoUseCaseError::PropertyNotFound("IsArchived".to_string()))?
-        {
-            PageProperty::Checkbox(is_done) => Ok(is_done.checkbox),
-            _ => Err(ToDoUseCaseError::PropertyNotFound("IsArchived".to_string())),
-        }?;
+    let is_archived = match response
+        .properties
+        .get("IsArchived")
+        .ok_or(ToDoUseCaseError::PropertyNotFound("IsArchived".to_string()))?
+    {
+        PageProperty::Checkbox(is_done) => Ok(is_done.checkbox),
+        _ => Err(ToDoUseCaseError::PropertyNotFound("IsArchived".to_string())),
+    }?;
 
-        let deadline = response
-            .properties
-            .get("Deadline")
-            .and_then(|deadline| match deadline {
-                PageProperty::Date(deadline) => deadline.date.as_ref().and_then(|d| {
-                    d.start.map(|start| match start {
-                        DateOrDateTime::Date(date) => date,
-                        DateOrDateTime::DateTime(dt) => dt.date(),
-                    })
-                }),
-                _ => None,
-            });
+    let deadline = response
+        .properties
+        .get("Deadline")
+        .and_then(|deadline| match deadline {
+            PageProperty::Date(deadline) => deadline.date.as_ref().and_then(|d| {
+                d.start.map(|start| match start {
+                    DateOrDateTime::Date(date) => date,
+                    DateOrDateTime::DateTime(dt) => dt.date(),
+                })
+            }),
+            _ => None,
+        });
 
-        let severity: ToDoSeverityEntity = response
-            .properties
-            .get("Severity")
-            .and_then(|s| {
-                if let PageProperty::Select(select) = s {
-                    select.select.as_ref().map(|select_name| {
-                        let select_name_str = select_name.to_string();
-                        let severity =
-                            serde_plain::from_str::<ToDoSeverityEntity>(&select_name_str)
-                                .inspect_err(|e| {
-                                    tracing::warn!("Unexpected variant detected in severity: {}", e)
-                                })
-                                .unwrap_or(ToDoSeverityEntity::Unknown);
-                        severity
-                    })
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(ToDoSeverityEntity::Unknown);
-
-        Ok(ToDoEntity {
-            id,
-            url,
-            source,
-            title,
-            description,
-            is_done,
-            is_recurring,
-            is_archived,
-            deadline,
-            severity,
-            created_at: Some(response.created_time.date()),
-            updated_at: Some(response.last_edited_time.date()),
+    let severity: ToDoSeverityEntity = response
+        .properties
+        .get("Severity")
+        .and_then(|s| {
+            if let PageProperty::Select(select) = s {
+                select.select.as_ref().map(|select_name| {
+                    let select_name_str = select_name.to_string();
+                    let severity = serde_plain::from_str::<ToDoSeverityEntity>(&select_name_str)
+                        .inspect_err(|e| {
+                            tracing::warn!("Unexpected variant detected in severity: {}", e)
+                        })
+                        .unwrap_or(ToDoSeverityEntity::Unknown);
+                    severity
+                })
+            } else {
+                None
+            }
         })
-    }
+        .unwrap_or(ToDoSeverityEntity::Unknown);
 
+    Ok(ToDoEntity {
+        id,
+        url,
+        source,
+        title,
+        description,
+        is_done,
+        is_recurring,
+        is_archived,
+        deadline,
+        severity,
+        created_at: Some(response.created_time.date()),
+        updated_at: Some(response.last_edited_time.date()),
+    })
+}
+
+impl ToDoUseCase {
     pub async fn create_to_do(
         &self,
         title: String,
@@ -207,7 +209,7 @@ impl ToDoUseCase {
 
         let page_response = self.to_do_repository.update_to_do(id, properties).await?;
 
-        let to_do_entity = self.convert_page_response_to_to_do_entity(&page_response)?;
+        let to_do_entity = convert_page_response_to_to_do_entity(&page_response)?;
 
         Ok(to_do_entity)
     }
@@ -222,7 +224,7 @@ impl ToDoUseCase {
         let todos = response
             .iter()
             .map(|page_response| {
-                let to_do_entity = self.convert_page_response_to_to_do_entity(page_response)?;
+                let to_do_entity = convert_page_response_to_to_do_entity(page_response)?;
                 Ok(to_do_entity)
             })
             .collect::<Result<Vec<ToDoEntity>, ToDoUseCaseError>>()?;
@@ -236,41 +238,286 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
-    async fn create_to_do() {
-        let to_do_repository = std::sync::Arc::new(crate::to_do::repository::ToDoRepositoryStub);
+    /// Builds a minimal `PageResponse` carrying the given properties, so tests
+    /// can exercise `convert_page_response_to_to_do_entity` against arbitrary
+    /// property sets without hand-writing the full struct each time. Mirrors the
+    /// `stub_page` helper in `trivia/repository/mod.rs`.
+    fn make_page(properties: std::collections::HashMap<String, PageProperty>) -> PageResponse {
+        let user = notionrs_types::object::user::User {
+            object: "user".to_string(),
+            id: "00000000-0000-0000-0000-000000000000".to_string(),
+            ..Default::default()
+        };
 
+        let ts = time::OffsetDateTime::parse(
+            "2025-02-22T13:33:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+
+        PageResponse {
+            id: "test-id".to_string(),
+            created_time: ts,
+            last_edited_time: ts,
+            created_by: user.clone(),
+            last_edited_by: user,
+            cover: None,
+            icon: None,
+            parent: notionrs_types::object::parent::Parent::PageParent(
+                notionrs_types::object::parent::PageParent {
+                    r#type: "page_id".to_string(),
+                    page_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                },
+            ),
+            #[allow(deprecated)]
+            archived: false,
+            properties,
+            url: "https://www.notion.so/test".to_string(),
+            public_url: None,
+            developer_survey: None,
+            request_id: None,
+            in_trash: false,
+            is_locked: false,
+            is_archived: false,
+        }
+    }
+
+    /// All properties required by the converter, with neutral defaults. Tests
+    /// override or remove individual entries to drive specific branches.
+    fn base_props() -> std::collections::HashMap<String, PageProperty> {
+        let mut p = std::collections::HashMap::new();
+        p.insert(
+            "Title".to_string(),
+            PageProperty::Title(PageTitleProperty::from("My Task".to_string())),
+        );
+        p.insert(
+            "IsDone".to_string(),
+            PageProperty::Checkbox(PageCheckboxProperty::from(false)),
+        );
+        p.insert(
+            "IsRecurring".to_string(),
+            PageProperty::Checkbox(PageCheckboxProperty::from(false)),
+        );
+        p.insert(
+            "IsArchived".to_string(),
+            PageProperty::Checkbox(PageCheckboxProperty::from(false)),
+        );
+        p
+    }
+
+    fn checkbox(value: bool) -> PageProperty {
+        PageProperty::Checkbox(PageCheckboxProperty::from(value))
+    }
+
+    fn select(name: &str) -> PageProperty {
+        PageProperty::Select(PageSelectProperty::from(name.to_string()))
+    }
+
+    // ---- convert_page_response_to_to_do_entity (pure) ----
+
+    #[test]
+    fn convert_fixture_happy_path() {
+        // The committed fixture: Severity null, no Description, deadline stored
+        // under "Date" (not "Deadline"), so several optional fields resolve to
+        // their empty form.
+        let page: PageResponse = serde_json::from_slice(include_bytes!("../to_do.json")).unwrap();
+
+        let entity = convert_page_response_to_to_do_entity(&page).unwrap();
+
+        assert_eq!(entity.title, "家族会議");
+        assert_eq!(entity.source, "Notion:todo");
+        assert!(!entity.is_done);
+        assert!(!entity.is_recurring);
+        assert!(!entity.is_archived);
+        assert_eq!(entity.severity, ToDoSeverityEntity::Unknown);
+        assert_eq!(entity.description, None);
+        // Fixture uses the "Date" property, which the converter does not read.
+        assert_eq!(entity.deadline, None);
+        assert_eq!(
+            entity.created_at,
+            Some(time::Date::from_calendar_date(2025, time::Month::February, 22).unwrap())
+        );
+    }
+
+    #[test]
+    fn missing_title_is_error() {
+        let mut props = base_props();
+        props.remove("Title");
+        let err = convert_page_response_to_to_do_entity(&make_page(props)).unwrap_err();
+        assert!(matches!(err, ToDoUseCaseError::PropertyNotFound(p) if p == "title"));
+    }
+
+    #[test]
+    fn missing_is_done_is_error() {
+        let mut props = base_props();
+        props.remove("IsDone");
+        let err = convert_page_response_to_to_do_entity(&make_page(props)).unwrap_err();
+        assert!(matches!(err, ToDoUseCaseError::PropertyNotFound(p) if p == "IsDone"));
+    }
+
+    #[test]
+    fn missing_is_recurring_is_error() {
+        let mut props = base_props();
+        props.remove("IsRecurring");
+        let err = convert_page_response_to_to_do_entity(&make_page(props)).unwrap_err();
+        assert!(matches!(err, ToDoUseCaseError::PropertyNotFound(p) if p == "IsRecurring"));
+    }
+
+    #[test]
+    fn missing_is_archived_is_error() {
+        let mut props = base_props();
+        props.remove("IsArchived");
+        let err = convert_page_response_to_to_do_entity(&make_page(props)).unwrap_err();
+        assert!(matches!(err, ToDoUseCaseError::PropertyNotFound(p) if p == "IsArchived"));
+    }
+
+    #[test]
+    fn is_done_wrong_type_is_error() {
+        let mut props = base_props();
+        props.insert("IsDone".to_string(), select("oops"));
+        let err = convert_page_response_to_to_do_entity(&make_page(props)).unwrap_err();
+        assert!(matches!(err, ToDoUseCaseError::PropertyNotFound(p) if p == "IsDone"));
+    }
+
+    #[test]
+    fn is_done_true_is_read() {
+        let mut props = base_props();
+        props.insert("IsDone".to_string(), checkbox(true));
+        let entity = convert_page_response_to_to_do_entity(&make_page(props)).unwrap();
+        assert!(entity.is_done);
+    }
+
+    #[test]
+    fn description_whitespace_only_is_none() {
+        let mut props = base_props();
+        props.insert(
+            "Description".to_string(),
+            PageProperty::RichText(PageRichTextProperty::from("   ".to_string())),
+        );
+        let entity = convert_page_response_to_to_do_entity(&make_page(props)).unwrap();
+        assert_eq!(entity.description, None);
+    }
+
+    #[test]
+    fn description_non_empty_is_some() {
+        let mut props = base_props();
+        props.insert(
+            "Description".to_string(),
+            PageProperty::RichText(PageRichTextProperty::from("hello".to_string())),
+        );
+        let entity = convert_page_response_to_to_do_entity(&make_page(props)).unwrap();
+        assert_eq!(entity.description, Some("hello".to_string()));
+    }
+
+    #[test]
+    fn severity_valid_variant_is_parsed() {
+        let mut props = base_props();
+        props.insert("Severity".to_string(), select("ERROR"));
+        let entity = convert_page_response_to_to_do_entity(&make_page(props)).unwrap();
+        assert_eq!(entity.severity, ToDoSeverityEntity::Error);
+    }
+
+    #[test]
+    fn severity_unknown_string_falls_back() {
+        let mut props = base_props();
+        props.insert("Severity".to_string(), select("BOGUS"));
+        let entity = convert_page_response_to_to_do_entity(&make_page(props)).unwrap();
+        assert_eq!(entity.severity, ToDoSeverityEntity::Unknown);
+    }
+
+    #[test]
+    fn deadline_date_is_read() {
+        let date = time::Date::from_calendar_date(2025, time::Month::March, 22).unwrap();
+        let mut props = base_props();
+        props.insert(
+            "Deadline".to_string(),
+            PageProperty::Date(PageDateProperty {
+                date: Some(PageDatePropertyParameter {
+                    start: Some(DateOrDateTime::Date(date)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        );
+        let entity = convert_page_response_to_to_do_entity(&make_page(props)).unwrap();
+        assert_eq!(entity.deadline, Some(date));
+    }
+
+    #[test]
+    fn deadline_datetime_keeps_date_part() {
+        let dt = time::OffsetDateTime::parse(
+            "2025-03-22T09:30:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+        let mut props = base_props();
+        props.insert(
+            "Deadline".to_string(),
+            PageProperty::Date(PageDateProperty {
+                date: Some(PageDatePropertyParameter {
+                    start: Some(DateOrDateTime::DateTime(dt)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        );
+        let entity = convert_page_response_to_to_do_entity(&make_page(props)).unwrap();
+        assert_eq!(entity.deadline, Some(dt.date()));
+    }
+
+    // ---- async use-case methods (via stub) ----
+
+    #[tokio::test]
+    async fn create_to_do_maps_inputs() {
+        let to_do_repository = std::sync::Arc::new(crate::to_do::repository::ToDoRepositoryStub);
         let to_do_use_case = ToDoUseCase { to_do_repository };
 
-        let _todos = to_do_use_case
+        let deadline = time::Date::from_calendar_date(2024, time::Month::April, 4).unwrap();
+        let entity = to_do_use_case
             .create_to_do(
                 "My Title".to_string(),
                 Some("My Description".to_string()),
                 None,
-                Some(time::Date::from_calendar_date(2024, time::Month::April, 4).unwrap()),
+                Some(deadline),
             )
             .await
             .unwrap();
+
+        assert_eq!(entity.title, "My Title");
+        assert_eq!(entity.source, "Notion:todo");
+        assert_eq!(entity.deadline, Some(deadline));
+        assert_eq!(entity.severity, ToDoSeverityEntity::Unknown);
+        assert!(!entity.is_done);
+        // description is read back from the (stub) response, which carries no
+        // Description property, so it resolves to None.
+        assert_eq!(entity.description, None);
     }
 
     #[tokio::test]
-    async fn update_to_do() {
+    async fn update_to_do_returns_converted_entity() {
         let to_do_repository = std::sync::Arc::new(crate::to_do::repository::ToDoRepositoryStub);
-
         let to_do_use_case = ToDoUseCase { to_do_repository };
 
-        let _todos = to_do_use_case
+        let entity = to_do_use_case
             .update_to_do("aab0c9e2-d945-4ba2-a7f2-0609fee58530".to_string(), true)
             .await
             .unwrap();
+
+        // The stub echoes the fixture, so the converted entity reflects it.
+        assert_eq!(entity.title, "家族会議");
+        assert_eq!(entity.source, "Notion:todo");
+        assert_eq!(entity.severity, ToDoSeverityEntity::Unknown);
     }
 
     #[tokio::test]
-    async fn list_notion_todo() {
+    async fn list_notion_todo_returns_one() {
         let to_do_repository = std::sync::Arc::new(crate::to_do::repository::ToDoRepositoryStub);
-
         let to_do_use_case = ToDoUseCase { to_do_repository };
 
-        let _todos = to_do_use_case.list_notion_to_do().await.unwrap();
+        let todos = to_do_use_case.list_notion_to_do().await.unwrap();
+
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].title, "家族会議");
+        assert_eq!(todos[0].source, "Notion:todo");
     }
 }

--- a/crates/http_api/src/to_do/use_case/mod.rs
+++ b/crates/http_api/src/to_do/use_case/mod.rs
@@ -92,12 +92,12 @@ fn convert_page_response_to_to_do_entity(
             if let PageProperty::Select(select) = s {
                 select.select.as_ref().map(|select_name| {
                     let select_name_str = select_name.to_string();
-                    let severity = serde_plain::from_str::<ToDoSeverityEntity>(&select_name_str)
+
+                    serde_plain::from_str::<ToDoSeverityEntity>(&select_name_str)
                         .inspect_err(|e| {
                             tracing::warn!("Unexpected variant detected in severity: {}", e)
                         })
-                        .unwrap_or(ToDoSeverityEntity::Unknown);
-                    severity
+                        .unwrap_or(ToDoSeverityEntity::Unknown)
                 })
             } else {
                 None

--- a/crates/http_api/src/trivia/use_case/mod.rs
+++ b/crates/http_api/src/trivia/use_case/mod.rs
@@ -134,9 +134,78 @@ mod tests {
         let trivia_repository = std::sync::Arc::new(TriviaRepositoryStub);
         let trivia_use_case = TriviaUseCase { trivia_repository };
 
-        let _ = trivia_use_case
+        let blocks = trivia_use_case
             .list_blocks("4a3720d5-fcdd-46f1-a7b8-51e168ac5e8e")
             .await
             .unwrap();
+
+        assert_eq!(blocks.surface["root"], "root");
+    }
+
+    // ---- normalize_root (pure) ----
+
+    use n2a2ui_a2ui::v0_9::{ChildList, Column, Component, Surface};
+
+    fn column(id: &str, children: &[&str]) -> Component {
+        Component::Column(Column {
+            id: id.to_string(),
+            children: ChildList::Static(children.iter().map(|s| s.to_string()).collect()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn normalize_root_rewrites_id_and_preserves_children() {
+        let mut components = indexmap::IndexMap::new();
+        components.insert("orig".to_string(), column("orig", &["a", "b"]));
+        components.insert("a".to_string(), column("a", &[]));
+        components.insert("b".to_string(), column("b", &[]));
+        let source = Surface {
+            root: "orig".to_string(),
+            components,
+        };
+
+        let result = normalize_root(source);
+
+        assert_eq!(result.root, SECTION_ROOT_ID);
+        assert!(result.components.contains_key(SECTION_ROOT_ID));
+        assert!(!result.components.contains_key("orig"));
+        match result.components.get(SECTION_ROOT_ID) {
+            Some(Component::Column(col)) => match &col.children {
+                ChildList::Static(ids) => {
+                    assert_eq!(ids, &vec!["a".to_string(), "b".to_string()])
+                }
+                _ => panic!("expected static children"),
+            },
+            _ => panic!("expected a Column at the root id"),
+        }
+        assert!(result.components.contains_key("a"));
+        assert!(result.components.contains_key("b"));
+    }
+
+    #[test]
+    fn normalize_root_non_column_root_yields_empty_children() {
+        let mut components = indexmap::IndexMap::new();
+        components.insert(
+            "orig".to_string(),
+            Component::RichText(n2a2ui_a2ui::v0_9::RichText {
+                id: "orig".to_string(),
+                ..Default::default()
+            }),
+        );
+        let source = Surface {
+            root: "orig".to_string(),
+            components,
+        };
+
+        let result = normalize_root(source);
+
+        match result.components.get(SECTION_ROOT_ID) {
+            Some(Component::Column(col)) => match &col.children {
+                ChildList::Static(ids) => assert!(ids.is_empty()),
+                _ => panic!("expected static children"),
+            },
+            _ => panic!("expected a Column at the root id"),
+        }
     }
 }

--- a/crates/http_api/src/typing/use_case/mod.rs
+++ b/crates/http_api/src/typing/use_case/mod.rs
@@ -65,42 +65,107 @@ impl TypingUseCase {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::typing::repository::output::TypingDto;
 
-    #[tokio::test]
-    async fn test_typing_list() -> Result<(), TypingUseCaseError> {
-        let typing_repository =
-            std::sync::Arc::new(crate::typing::repository::TypingRepositoryStub);
+    /// A stub that echoes the `id` it was handed back into the returned record,
+    /// so tests can observe whether the use case generated a UUID or passed the
+    /// caller's id through. The default `TypingRepositoryStub` discards the id,
+    /// which hides that branch.
+    struct EchoIdStub;
 
-        let typing_use_case = TypingUseCase { typing_repository };
+    #[async_trait::async_trait]
+    impl crate::typing::repository::TypingRepository for EchoIdStub {
+        async fn typing_list(
+            &self,
+        ) -> Result<Vec<TypingDto>, crate::typing::repository::TypingRepositoryError> {
+            unreachable!("not used in these tests")
+        }
 
-        let _ = typing_use_case.typing_list().await?;
+        async fn upsert_typing(
+            &self,
+            id: String,
+            text: String,
+            description: String,
+        ) -> Result<TypingDto, crate::typing::repository::TypingRepositoryError> {
+            Ok(TypingDto {
+                id,
+                text,
+                description,
+            })
+        }
 
-        Ok(())
+        async fn delete_typing(
+            &self,
+            id: String,
+        ) -> Result<TypingDto, crate::typing::repository::TypingRepositoryError> {
+            Ok(TypingDto {
+                id,
+                text: String::new(),
+                description: String::new(),
+            })
+        }
     }
 
     #[tokio::test]
-    async fn test_upsert_typing() -> Result<(), TypingUseCaseError> {
-        let typing_repository =
-            std::sync::Arc::new(crate::typing::repository::TypingRepositoryStub);
+    async fn typing_list_maps_records() {
+        let typing_use_case = TypingUseCase {
+            typing_repository: std::sync::Arc::new(crate::typing::repository::TypingRepositoryStub),
+        };
 
-        let typing_use_case = TypingUseCase { typing_repository };
+        let list = typing_use_case.typing_list().await.unwrap();
 
-        let _ = typing_use_case
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].id, "93165a44-43c8-4790-84ad-08de54ec549a");
+        assert_eq!(list[0].text, "text");
+        assert_eq!(list[0].description, "description");
+    }
+
+    #[tokio::test]
+    async fn upsert_with_none_id_generates_uuid() {
+        let typing_use_case = TypingUseCase {
+            typing_repository: std::sync::Arc::new(EchoIdStub),
+        };
+
+        let entity = typing_use_case
             .upsert_typing(None, "text".to_string(), "description".to_string())
-            .await?;
+            .await
+            .unwrap();
 
-        Ok(())
+        // The use case fills in a v4 UUID, which the echo stub returns verbatim.
+        assert!(uuid::Uuid::parse_str(&entity.id).is_ok());
+        assert_eq!(entity.text, "text");
+        assert_eq!(entity.description, "description");
     }
 
     #[tokio::test]
-    async fn test_delete_typing() -> Result<(), TypingUseCaseError> {
-        let typing_repository =
-            std::sync::Arc::new(crate::typing::repository::TypingRepositoryStub);
+    async fn upsert_with_some_id_passes_it_through() {
+        let typing_use_case = TypingUseCase {
+            typing_repository: std::sync::Arc::new(EchoIdStub),
+        };
 
-        let typing_use_case = TypingUseCase { typing_repository };
+        let entity = typing_use_case
+            .upsert_typing(
+                Some("my-id".to_string()),
+                "text".to_string(),
+                "description".to_string(),
+            )
+            .await
+            .unwrap();
 
-        let _ = typing_use_case.delete_typing("id".to_string()).await?;
+        assert_eq!(entity.id, "my-id");
+    }
 
-        Ok(())
+    #[tokio::test]
+    async fn delete_typing_maps_record() {
+        let typing_use_case = TypingUseCase {
+            typing_repository: std::sync::Arc::new(crate::typing::repository::TypingRepositoryStub),
+        };
+
+        let entity = typing_use_case
+            .delete_typing("id".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(entity.id, "680008c4-d898-4202-8102-137cd9256595");
     }
 }

--- a/crates/http_api/tests/get_parameter.rs
+++ b/crates/http_api/tests/get_parameter.rs
@@ -1,7 +1,8 @@
 use http_api::cache::get_parameter;
 
 #[tokio::test]
-async fn test_get_parameter() {
+#[ignore = "live: reads a real SSM Parameter Store value, requires AWS credentials"]
+async fn live_get_parameter() {
     let parameter_name = "/dev/46ki75/internal/notion/anki/data_source/id".to_owned();
 
     let start = std::time::Instant::now();

--- a/crates/http_api/tests/image_repository.rs
+++ b/crates/http_api/tests/image_repository.rs
@@ -1,7 +1,8 @@
 use http_api::image::repository::{ImageRepository, ImageRepositoryImpl};
 
 #[tokio::test]
-async fn test_fetch_image_tags() {
+#[ignore = "live: hits Notion via AWS-backed config, requires network + credentials"]
+async fn live_fetch_image_tags() {
     let repository = ImageRepositoryImpl {};
 
     let result = repository.fetch_image_tags().await;
@@ -12,7 +13,8 @@ async fn test_fetch_image_tags() {
 }
 
 #[tokio::test]
-async fn test_fetch_images() {
+#[ignore = "live: hits Notion via AWS-backed config, requires network + credentials"]
+async fn live_fetch_images() {
     let repository = ImageRepositoryImpl {};
 
     let result = repository.fetch_images().await;

--- a/crates/logs-reporter/src/event_handler.rs
+++ b/crates/logs-reporter/src/event_handler.rs
@@ -2,6 +2,9 @@ use aws_config::BehaviorVersion;
 use aws_lambda_events::event::cloudwatch_logs::LogsEvent;
 use lambda_runtime::{Error, LambdaEvent};
 
+// Variants intentionally match the uppercase CloudWatch/syslog level names;
+// they are surfaced verbatim in alert emails via `{:?}`.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug)]
 enum Level {
     DEBUG,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.93.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
First step of the Rust refactor: a real test foundation for `crates/http_api` plus workspace-wide CI.

## What's in here

**Tests (`5196301`)**
- Converts smoke tests (`.unwrap()` with no assertions) into real unit tests across `http_api` use_cases; suite grows **14 → 45** passing.
- Light refactor: extracts pure logic into free functions so it's directly testable — `convert_page_response_to_to_do_entity`, `partition_blocks_by_section` (anki), `resolve_favicon_url` (bookmark). Behavior unchanged.
- Adds `cargo-llvm-cov` coverage recipes to the `http_api` Justfile.

**CI gate (`39497ec`)**
- `rust-ci.yml`: hermetic PR gate running `just ci` (fmt-check, clippy `-D warnings`, hermetic tests) against the `rust-toolchain.toml` pin.
- `rust-live.yml`: `workflow_dispatch`-only live tier behind a `live` environment.
- Root `Justfile`: `fmt-check` / `lint` / `test` / `test-live` / `ci` / `ci-live`.
- Clears the 23 pre-existing clippy warnings so the gate is green (boxes the ~360B SSM `SdkError`, adds a `BoxFuture` alias in feed, allows `upper_case_acronyms` on log-level names, plus `clippy --fix` cleanups — all behavior-preserving).
- Gates the live integration tests with `#[ignore]` + a `live_` prefix so the default `cargo test` is hermetic.

**Coverage (`045ae0b`, `09e3530`)**
- Report-only coverage job: per-file summary in the GitHub job summary + `lcov.info` artifact, plus Codecov upload (`CODECOV_TOKEN` is set).
- `codecov.yml` keeps all status checks informational — coverage reports but never gates a merge.

## Notes
- Scope is `http_api` tests only; `feed`/`logs-reporter` are touched only for the workspace-wide clippy gate.
- Coverage is intentionally non-blocking (guardrail, not a target). Workspace line coverage is ~40% overall, with tested use_cases high (e.g. typing ~96%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)