### PR TITLE
test(http_api): cover icon/image/tts use_cases

### DIFF
--- a/crates/http_api/src/icon/repository/mod.rs
+++ b/crates/http_api/src/icon/repository/mod.rs
@@ -3,6 +3,7 @@ pub mod output;
 
 use futures::TryStreamExt;
 use futures::stream::StreamExt;
+use http::header::CONTENT_TYPE;
 use notionrs::PaginateExt;
 
 #[derive(Debug, thiserror::Error)]
@@ -19,6 +20,13 @@ pub trait IconRepository {
     ) -> std::pin::Pin<
         Box<dyn Future<Output = Result<Vec<self::output::IconDto>, IconRepositoryError>> + Send>,
     >;
+
+    /// Resolves the `Content-Type` of an icon via a `HEAD` request. Kept on the
+    /// repository (not the use_case) so the use_case stays I/O-free and testable.
+    fn fetch_content_type(
+        &self,
+        url: String,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Option<String>, IconRepositoryError>> + Send>>;
 }
 
 #[derive(Debug, Default)]
@@ -53,5 +61,56 @@ impl IconRepository for IconRepositoryImpl {
 
             Ok(icons)
         })
+    }
+
+    fn fetch_content_type(
+        &self,
+        url: String,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Option<String>, IconRepositoryError>> + Send>>
+    {
+        Box::pin(async move {
+            let client = crate::cache::get_or_init_reqwest_client().await?;
+
+            let content_type = client.head(&url).send().await.ok().and_then(|res| {
+                res.headers()
+                    .get(CONTENT_TYPE)
+                    .and_then(|c| c.to_str().ok().map(|s| s.to_string()))
+            });
+
+            Ok(content_type)
+        })
+    }
+}
+
+pub struct IconRepositoryStub;
+
+impl IconRepository for IconRepositoryStub {
+    fn list_icons(
+        &self,
+    ) -> std::pin::Pin<
+        Box<dyn Future<Output = Result<Vec<self::output::IconDto>, IconRepositoryError>> + Send>,
+    > {
+        Box::pin(async move {
+            Ok(vec![
+                self::output::IconDto {
+                    id: "icon-1".to_string(),
+                    url: "https://example.com/alpha.png".to_string(),
+                    name: "alpha".to_string(),
+                },
+                self::output::IconDto {
+                    id: "icon-2".to_string(),
+                    url: "https://example.com/beta.png".to_string(),
+                    name: "beta".to_string(),
+                },
+            ])
+        })
+    }
+
+    fn fetch_content_type(
+        &self,
+        _url: String,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Option<String>, IconRepositoryError>> + Send>>
+    {
+        Box::pin(async move { Ok(Some("image/png".to_string())) })
     }
 }

--- a/crates/http_api/src/icon/use_case/mod.rs
+++ b/crates/http_api/src/icon/use_case/mod.rs
@@ -3,7 +3,6 @@ pub mod output;
 
 use crate::icon::repository::{IconRepository, IconRepositoryError};
 use futures::future::join_all;
-use http::header::CONTENT_TYPE;
 use output::IconEntiry;
 
 #[derive(Debug, thiserror::Error)]
@@ -23,26 +22,47 @@ impl IconUseCase {
         let icons: Vec<crate::icon::repository::output::IconDto> =
             self.icon_repository.list_icons().await?;
 
-        let icon_list = join_all(icons.into_iter().map(|icon| async move {
-            let client = crate::cache::get_or_init_reqwest_client().await?;
+        let icon_list = join_all(icons.into_iter().map(|icon| {
+            let repository = self.icon_repository.clone();
+            async move {
+                let content_type = repository.fetch_content_type(icon.url.clone()).await?;
 
-            let mime_type = client.head(&icon.url).send().await.ok().and_then(|res| {
-                res.headers()
-                    .get(CONTENT_TYPE)
-                    .and_then(|c| c.to_str().ok().map(|s| s.to_string()))
-            });
-
-            Ok::<IconEntiry, crate::error::Error>(IconEntiry {
-                id: icon.id,
-                url: icon.url,
-                name: icon.name,
-                content_type: mime_type,
-            })
+                Ok::<IconEntiry, IconUseCaseError>(IconEntiry {
+                    id: icon.id,
+                    url: icon.url,
+                    name: icon.name,
+                    content_type,
+                })
+            }
         }))
         .await
         .into_iter()
-        .collect::<Result<Vec<IconEntiry>, crate::error::Error>>()?;
+        .collect::<Result<Vec<IconEntiry>, IconUseCaseError>>()?;
 
         Ok(icon_list)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::icon::repository::IconRepositoryStub;
+
+    #[tokio::test]
+    async fn list_icons_maps_dtos_and_content_type() {
+        let icon_use_case = IconUseCase {
+            icon_repository: std::sync::Arc::new(IconRepositoryStub),
+        };
+
+        let icons = icon_use_case.list_icons().await.unwrap();
+
+        // join_all preserves input order, so icons line up with the stub's list.
+        assert_eq!(icons.len(), 2);
+        assert_eq!(icons[0].id, "icon-1");
+        assert_eq!(icons[0].url, "https://example.com/alpha.png");
+        assert_eq!(icons[0].name, "alpha");
+        // The stub resolves a fixed MIME for every icon.
+        assert_eq!(icons[0].content_type.as_deref(), Some("image/png"));
+        assert_eq!(icons[1].id, "icon-2");
     }
 }

--- a/crates/http_api/src/image/repository/mod.rs
+++ b/crates/http_api/src/image/repository/mod.rs
@@ -165,3 +165,97 @@ impl ImageRepository for ImageRepositoryImpl {
         })
     }
 }
+
+pub struct ImageRepositoryStub;
+
+impl ImageRepository for ImageRepositoryStub {
+    fn fetch_images(
+        &self,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<self::output::ImagePageDto, ImageRepositoryError>> + Send>,
+    > {
+        Box::pin(async move {
+            let image = self::output::ImageDto {
+                title: PageTitleProperty {
+                    title: vec![RichText::from("alpha".to_string())],
+                    ..Default::default()
+                },
+                name: PageRichTextProperty {
+                    rich_text: vec![RichText::from("alpha-name".to_string())],
+                    ..Default::default()
+                },
+                sources: PageMultiSelectProperty::default(),
+                url: PageUrlProperty {
+                    url: Some("https://example.com/alpha.png".to_string()),
+                    ..Default::default()
+                },
+                tags: PageRelationProperty::default(),
+                notable_tags: PageRelationProperty::default(),
+                uploaded_at: PageDateProperty::default(),
+                images: PageFilesProperty::default(),
+            };
+
+            Ok(self::output::ImagePageDto {
+                images: vec![image],
+                next_cursor: None,
+            })
+        })
+    }
+
+    fn fetch_image_tags(
+        &self,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<Vec<self::output::ImageTagDto>, ImageRepositoryError>>
+                + Send,
+        >,
+    > {
+        Box::pin(async move {
+            Ok(vec![self::output::ImageTagDto {
+                tag_name: PageTitleProperty {
+                    title: vec![RichText::from("artist-tag".to_string())],
+                    ..Default::default()
+                },
+                url: PageUrlProperty {
+                    url: Some("https://example.com/artist".to_string()),
+                    ..Default::default()
+                },
+                tag_type: PageSelectProperty {
+                    select: Some(Select {
+                        name: "Artist".to_string(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            }])
+        })
+    }
+
+    fn create_image_tag(
+        &self,
+        tag_name: String,
+        url: String,
+        tag_type: self::output::ImageTagTypeDtoInput,
+    ) -> Pin<Box<dyn Future<Output = Result<self::output::ImageTagDto, ImageRepositoryError>> + Send>>
+    {
+        Box::pin(async move {
+            Ok(self::output::ImageTagDto {
+                tag_name: PageTitleProperty {
+                    title: vec![RichText::from(tag_name)],
+                    ..Default::default()
+                },
+                url: PageUrlProperty {
+                    url: Some(url),
+                    ..Default::default()
+                },
+                tag_type: PageSelectProperty {
+                    select: Some(Select {
+                        name: serde_plain::to_string(&tag_type).unwrap_or_default(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            })
+        })
+    }
+}

--- a/crates/http_api/src/image/use_case/mod.rs
+++ b/crates/http_api/src/image/use_case/mod.rs
@@ -28,3 +28,41 @@ impl ImageUseCase {
         Ok(dtos.into_iter().map(output::ImageTagOutput::from).collect())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image::repository::ImageRepositoryStub;
+
+    #[tokio::test]
+    async fn fetch_images_maps_dtos() {
+        let use_case = ImageUseCase {
+            repository: Arc::new(ImageRepositoryStub),
+        };
+
+        let page = use_case.fetch_images().await.unwrap();
+
+        assert_eq!(page.images.len(), 1);
+        assert_eq!(page.images[0].title, "alpha");
+        assert_eq!(page.images[0].name, "alpha-name");
+        assert_eq!(
+            page.images[0].url.as_deref(),
+            Some("https://example.com/alpha.png")
+        );
+        assert!(page.next_cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_image_tags_maps_dtos() {
+        let use_case = ImageUseCase {
+            repository: Arc::new(ImageRepositoryStub),
+        };
+
+        let tags = use_case.fetch_image_tags().await.unwrap();
+
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].tag_name, "artist-tag");
+        assert_eq!(tags[0].url, "https://example.com/artist");
+        assert_eq!(tags[0].tag_type, "Artist");
+    }
+}

--- a/crates/http_api/src/tts/repository.rs
+++ b/crates/http_api/src/tts/repository.rs
@@ -61,3 +61,16 @@ impl TtsRepository for TtsRepositoryImpl {
         })
     }
 }
+
+pub struct TtsRepositoryStub;
+
+impl TtsRepository for TtsRepositoryStub {
+    fn text_to_speach(
+        &self,
+        _text: &str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<bytes::Bytes, crate::error::Error>> + Send>,
+    > {
+        Box::pin(async move { Ok(bytes::Bytes::from_static(b"stub-audio-bytes")) })
+    }
+}

--- a/crates/http_api/src/tts/use_case.rs
+++ b/crates/http_api/src/tts/use_case.rs
@@ -16,3 +16,32 @@ impl TtsService {
         Ok(bytes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tts::repository::TtsRepositoryStub;
+
+    #[tokio::test]
+    async fn text_to_speach_passes_bytes_through() {
+        let service = TtsService {
+            tts_repository: Arc::new(TtsRepositoryStub),
+        };
+
+        let bytes = service.text_to_speach("hello").await.unwrap();
+
+        assert_eq!(bytes.as_ref(), b"stub-audio-bytes");
+    }
+
+    #[test]
+    fn infer_detects_png_magic() {
+        let service = TtsService {
+            tts_repository: Arc::new(TtsRepositoryStub),
+        };
+
+        // 8-byte PNG signature — enough for `infer` to classify the bytes.
+        let png = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\n");
+
+        assert_eq!(service.infer(png), "image/png");
+    }
+}


### PR DESCRIPTION
Brings the three remaining features (`icon`, `image`, `tts`) up to the existing use-case-layer testing standard — hermetic stub injected via `Arc<dyn Repository>`, no mocking crate. Follows the approved layered-testing plan.

## Changes

**`icon` — fix the network leak, then test**
- `IconUseCase::list_icons` previously issued a `HEAD` request per icon *inline*, bypassing the repository and making the use_case impossible to test offline.
- Moved that into `IconRepository::fetch_content_type`; `list_icons` is now pure orchestration over the repository.
- Added `IconRepositoryStub` + a test asserting the mapped ids/urls/`content_type`.

**`image` — stub + tests**
- Added `ImageRepositoryStub` and tests for `fetch_images` / `fetch_image_tags`, asserting the `From<Dto> → *Output` mapping.
- **Deviation from plan:** built the stub DTOs programmatically rather than from a `.json` fixture. Capturing a real fixture needs AWS creds, and hand-writing valid Notion `RichText` JSON is fragile; all eight `PageProperty` types derive `Default`, so programmatic construction is compiler-checked and deterministic. Matches the existing `TypingRepositoryStub` precedent.

**`tts` — stub + tests**
- Added `TtsRepositoryStub`; tested byte pass-through and the pure `infer()` MIME detection against a PNG magic header.

## Verification
- `just ci` green: fmt clean, clippy clean under `-D warnings`, **50 hermetic tests** (was 45), all offline (no AWS/network).
- Coverage now reports on the three previously-0% files: image use_case 100%, tts use_case 98%, icon use_case 52%.

## Scope
Use_case + repository layers only — `init_*_router` / `schema.rs` untouched. No new dev-dependencies. Live tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)