### PR TITLE
test(http_api): add API/wiring integration tier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,6 +1981,7 @@ dependencies = [
  "futures",
  "html-meta-scraper 0.2.0",
  "http 1.4.0",
+ "http-body-util",
  "indexmap",
  "infer",
  "lambda_http",

--- a/crates/http_api/Cargo.toml
+++ b/crates/http_api/Cargo.toml
@@ -67,3 +67,8 @@ utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 cached = { version = "0.59.0", features = ["async"] }
 serde_plain = "1.0.2"
+
+[dev-dependencies]
+# In-process API tests drive the router via `oneshot` and read response bodies.
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"

--- a/crates/http_api/src/anki/controller/router.rs
+++ b/crates/http_api/src/anki/controller/router.rs
@@ -16,14 +16,18 @@ pub async fn init_anki_router()
         anki_use_case: use_case,
     });
 
-    let (router, api) = OpenApiRouter::new()
+    Ok(anki_router(state))
+}
+
+/// Builds the anki router from injected state. Split out from
+/// [`init_anki_router`] so tests can drive it with a stub-backed use_case.
+pub fn anki_router(state: Arc<AnkiState>) -> (axum::Router, utoipa::openapi::OpenApi) {
+    OpenApiRouter::new()
         .routes(routes!(crate::anki::controller::anki))
         .routes(routes!(crate::anki::controller::anki_list))
         .routes(routes!(crate::anki::controller::block_list))
         .routes(routes!(crate::anki::controller::create_anki))
         .routes(routes!(crate::anki::controller::update_anki))
         .with_state(state)
-        .split_for_parts();
-
-    Ok((router, api))
+        .split_for_parts()
 }

--- a/crates/http_api/src/bookmark/controller/router.rs
+++ b/crates/http_api/src/bookmark/controller/router.rs
@@ -16,11 +16,15 @@ pub async fn init_bookmark_router()
         bookmark_use_case: use_case,
     });
 
-    let (router, api) = OpenApiRouter::new()
+    Ok(bookmark_router(state))
+}
+
+/// Builds the bookmark router from injected state. Split out from
+/// [`init_bookmark_router`] so tests can drive it with a stub-backed use_case.
+pub fn bookmark_router(state: Arc<BookmarkState>) -> (axum::Router, utoipa::openapi::OpenApi) {
+    OpenApiRouter::new()
         .routes(routes!(crate::bookmark::controller::bookmark_list))
         .routes(routes!(crate::bookmark::controller::create_bookmark))
         .with_state(state)
-        .split_for_parts();
-
-    Ok((router, api))
+        .split_for_parts()
 }

--- a/crates/http_api/src/icon/controller/router.rs
+++ b/crates/http_api/src/icon/controller/router.rs
@@ -15,10 +15,14 @@ pub async fn init_icon_router()
         icon_use_case: use_case,
     });
 
-    let (router, api) = OpenApiRouter::new()
+    Ok(icon_router(state))
+}
+
+/// Builds the icon router from injected state. Split out from
+/// [`init_icon_router`] so tests can drive it with a stub-backed use_case.
+pub fn icon_router(state: Arc<IconState>) -> (axum::Router, utoipa::openapi::OpenApi) {
+    OpenApiRouter::new()
         .routes(routes!(crate::icon::controller::list_icons))
         .with_state(state)
-        .split_for_parts();
-
-    Ok((router, api))
+        .split_for_parts()
 }

--- a/crates/http_api/src/image/controller/router.rs
+++ b/crates/http_api/src/image/controller/router.rs
@@ -15,11 +15,15 @@ pub async fn init_image_router()
         image_use_case: use_case,
     });
 
-    let (router, api) = OpenApiRouter::new()
+    Ok(image_router(state))
+}
+
+/// Builds the image router from injected state. Split out from
+/// [`init_image_router`] so tests can drive it with a stub-backed use_case.
+pub fn image_router(state: Arc<ImageState>) -> (axum::Router, utoipa::openapi::OpenApi) {
+    OpenApiRouter::new()
         .routes(routes!(crate::image::controller::fetch_images))
         .routes(routes!(crate::image::controller::fetch_image_tags))
         .with_state(state)
-        .split_for_parts();
-
-    Ok((router, api))
+        .split_for_parts()
 }

--- a/crates/http_api/src/schema.rs
+++ b/crates/http_api/src/schema.rs
@@ -1,8 +1,29 @@
 use async_graphql::{EmptySubscription, Schema};
+use std::sync::Arc;
 
-static SCHEMA: tokio::sync::OnceCell<
-    Schema<crate::query::QueryRoot, crate::mutation::MutationRoot, EmptySubscription>,
-> = tokio::sync::OnceCell::const_new();
+type ApiSchema = Schema<crate::query::QueryRoot, crate::mutation::MutationRoot, EmptySubscription>;
+
+static SCHEMA: tokio::sync::OnceCell<ApiSchema> = tokio::sync::OnceCell::const_new();
+
+/// Assembles the GraphQL schema from injected use_cases. Split out from
+/// [`try_init_schema`] so tests can build a schema backed by stub repositories.
+pub fn build_schema(
+    anki_use_case: Arc<crate::anki::use_case::AnkiUseCase>,
+    bookmark_use_case: Arc<crate::bookmark::use_case::BookmarkUseCase>,
+    to_do_use_case: Arc<crate::to_do::use_case::ToDoUseCase>,
+    typing_use_case: Arc<crate::typing::use_case::TypingUseCase>,
+) -> ApiSchema {
+    Schema::build(
+        crate::query::QueryRoot::default(),
+        crate::mutation::MutationRoot::default(),
+        EmptySubscription,
+    )
+    .data(anki_use_case)
+    .data(bookmark_use_case)
+    .data(to_do_use_case)
+    .data(typing_use_case)
+    .finish()
+}
 
 pub async fn try_init_schema() -> Result<
     &'static Schema<crate::query::QueryRoot, crate::mutation::MutationRoot, EmptySubscription>,
@@ -38,19 +59,13 @@ pub async fn try_init_schema() -> Result<
             let typing_use_case =
                 std::sync::Arc::new(crate::typing::use_case::TypingUseCase { typing_repository });
 
-            tracing::debug!("Building schema: QueryRoot");
-            let query_root = crate::query::QueryRoot::default();
-
-            tracing::debug!("Building schema: MutationRoot");
-            let mutation_root = crate::mutation::MutationRoot::default();
-
             tracing::debug!("Building schema: Schema");
-            Ok(Schema::build(query_root, mutation_root, EmptySubscription)
-                .data(anki_use_case)
-                .data(bookmark_use_case)
-                .data(to_do_use_case)
-                .data(typing_use_case)
-                .finish())
+            Ok(build_schema(
+                anki_use_case,
+                bookmark_use_case,
+                to_do_use_case,
+                typing_use_case,
+            ))
         })
         .await
 }

--- a/crates/http_api/src/to_do/controller/router.rs
+++ b/crates/http_api/src/to_do/controller/router.rs
@@ -15,12 +15,16 @@ pub async fn init_to_do_router()
         to_do_use_case: use_case,
     });
 
-    let (router, api) = OpenApiRouter::new()
+    Ok(to_do_router(state))
+}
+
+/// Builds the to_do router from injected state. Split out from
+/// [`init_to_do_router`] so tests can drive it with a stub-backed use_case.
+pub fn to_do_router(state: Arc<ToDoState>) -> (axum::Router, utoipa::openapi::OpenApi) {
+    OpenApiRouter::new()
         .routes(routes!(crate::to_do::controller::to_do_list))
         .routes(routes!(crate::to_do::controller::create_to_do))
         .routes(routes!(crate::to_do::controller::update_to_do))
         .with_state(state)
-        .split_for_parts();
-
-    Ok((router, api))
+        .split_for_parts()
 }

--- a/crates/http_api/src/trivia/controller/router.rs
+++ b/crates/http_api/src/trivia/controller/router.rs
@@ -16,12 +16,16 @@ pub async fn init_trivia_router()
         trivia_use_case: use_case,
     });
 
-    let (router, api) = OpenApiRouter::new()
+    Ok(trivia_router(state))
+}
+
+/// Builds the trivia router from injected state. Split out from
+/// [`init_trivia_router`] so tests can drive it with a stub-backed use_case.
+pub fn trivia_router(state: Arc<TriviaState>) -> (axum::Router, utoipa::openapi::OpenApi) {
+    OpenApiRouter::new()
         .routes(routes!(crate::trivia::controller::trivia_list))
         .routes(routes!(crate::trivia::controller::trivia_block_list))
         .routes(routes!(crate::trivia::controller::increment_view))
         .with_state(state)
-        .split_for_parts();
-
-    Ok((router, api))
+        .split_for_parts()
 }

--- a/crates/http_api/src/typing/controller/router.rs
+++ b/crates/http_api/src/typing/controller/router.rs
@@ -15,12 +15,16 @@ pub async fn init_typing_router()
         typing_use_case: use_case,
     });
 
-    let (router, api) = OpenApiRouter::new()
+    Ok(typing_router(state))
+}
+
+/// Builds the typing router from injected state. Split out from
+/// [`init_typing_router`] so tests can drive it with a stub-backed use_case.
+pub fn typing_router(state: Arc<TypingState>) -> (axum::Router, utoipa::openapi::OpenApi) {
+    OpenApiRouter::new()
         .routes(routes!(crate::typing::controller::typing_list))
         .routes(routes!(crate::typing::controller::upsert_typing))
         .routes(routes!(crate::typing::controller::delete_typing))
         .with_state(state)
-        .split_for_parts();
-
-    Ok((router, api))
+        .split_for_parts()
 }

--- a/crates/http_api/tests/api_graphql.rs
+++ b/crates/http_api/tests/api_graphql.rs
@@ -1,0 +1,75 @@
+//! In-process GraphQL API/wiring tests.
+//!
+//! Builds the real GraphQL schema (`build_schema`) with stub-backed use_cases
+//! and executes queries against it, exercising resolver wiring and the
+//! `ctx.data::<Arc<UseCase>>()` injection. Hermetic: no network/AWS.
+
+use std::sync::Arc;
+
+use http_api::schema::build_schema;
+
+type ApiSchema = async_graphql::Schema<
+    http_api::query::QueryRoot,
+    http_api::mutation::MutationRoot,
+    async_graphql::EmptySubscription,
+>;
+
+/// A schema with every feature use_case backed by its repository stub.
+fn stub_schema() -> ApiSchema {
+    build_schema(
+        Arc::new(http_api::anki::use_case::AnkiUseCase {
+            anki_repository: Arc::new(http_api::anki::repository::AnkiRepositoryStub),
+        }),
+        Arc::new(http_api::bookmark::use_case::BookmarkUseCase {
+            bookmark_repository: Arc::new(http_api::bookmark::repository::BookmarkRepositoryStub),
+        }),
+        Arc::new(http_api::to_do::use_case::ToDoUseCase {
+            to_do_repository: Arc::new(http_api::to_do::repository::ToDoRepositoryStub),
+        }),
+        Arc::new(http_api::typing::use_case::TypingUseCase {
+            typing_repository: Arc::new(http_api::typing::repository::TypingRepositoryStub),
+        }),
+    )
+}
+
+/// Execute `query`, asserting no GraphQL errors, and return the `data` as JSON.
+async fn exec(query: &str) -> serde_json::Value {
+    let response = stub_schema().execute(query).await;
+    assert!(response.errors.is_empty(), "errors: {:?}", response.errors);
+    serde_json::to_value(&response.data).unwrap()
+}
+
+#[tokio::test]
+async fn typing_list_query() {
+    let data = exec("{ typingList { id text description } }").await;
+
+    let rows = data["typingList"].as_array().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["id"], "93165a44-43c8-4790-84ad-08de54ec549a");
+    assert_eq!(rows[0]["text"], "text");
+}
+
+#[tokio::test]
+async fn bookmark_list_query() {
+    let data = exec("{ bookmarkList { id name } }").await;
+
+    let rows = data["bookmarkList"].as_array().unwrap();
+    assert_eq!(rows[0]["name"], "三菱UFJダイレクト");
+}
+
+#[tokio::test]
+async fn to_do_list_query() {
+    let data = exec("{ toDoList { id title isDone } }").await;
+
+    let rows = data["toDoList"].as_array().unwrap();
+    assert!(!rows.is_empty());
+    assert!(rows[0]["title"].is_string());
+}
+
+#[tokio::test]
+async fn unknown_field_is_a_query_error() {
+    // A field that doesn't exist should surface as a GraphQL validation error,
+    // not a panic or a 500.
+    let response = stub_schema().execute("{ thisFieldDoesNotExist }").await;
+    assert!(!response.errors.is_empty());
+}

--- a/crates/http_api/tests/api_rest.rs
+++ b/crates/http_api/tests/api_rest.rs
@@ -1,0 +1,212 @@
+//! In-process REST API/wiring tests.
+//!
+//! Each test boots a feature's real Axum router with a stub-backed use_case
+//! (via the `*_router(state)` seam) and drives it through `oneshot`. This
+//! exercises routing, extractors, response serialization, and error mapping —
+//! the layers the use_case unit tests don't reach. Hermetic: no network/AWS.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt; // brings `oneshot` into scope
+
+/// GET `path` on `router` and return the status plus the parsed JSON body.
+async fn get_json(router: axum::Router, path: &str) -> (StatusCode, serde_json::Value) {
+    let response = router
+        .oneshot(Request::get(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json = if body.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&body).unwrap()
+    };
+
+    (status, json)
+}
+
+// ---- anki ----
+
+fn anki_test_router() -> axum::Router {
+    let state = Arc::new(http_api::anki::controller::router::AnkiState {
+        anki_use_case: Arc::new(http_api::anki::use_case::AnkiUseCase {
+            anki_repository: Arc::new(http_api::anki::repository::AnkiRepositoryStub),
+        }),
+    });
+    http_api::anki::controller::router::anki_router(state).0
+}
+
+#[tokio::test]
+async fn anki_get_returns_stub_card() {
+    let (status, json) = get_json(anki_test_router(), "/api/v1/anki/any-id").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["page_id"], "4a3720d5-fcdd-46f1-a7b8-51e168ac5e8e");
+    assert_eq!(json["ease_factor"], 2.5);
+}
+
+// ---- bookmark ----
+
+fn bookmark_test_router() -> axum::Router {
+    let state = Arc::new(http_api::bookmark::controller::router::BookmarkState {
+        bookmark_use_case: Arc::new(http_api::bookmark::use_case::BookmarkUseCase {
+            bookmark_repository: Arc::new(http_api::bookmark::repository::BookmarkRepositoryStub),
+        }),
+    });
+    http_api::bookmark::controller::router::bookmark_router(state).0
+}
+
+#[tokio::test]
+async fn bookmark_list_returns_stub_row() {
+    let (status, json) = get_json(bookmark_test_router(), "/api/v1/bookmark").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json[0]["name"], "三菱UFJダイレクト");
+}
+
+// ---- icon ----
+
+fn icon_test_router() -> axum::Router {
+    let state = Arc::new(http_api::icon::controller::router::IconState {
+        icon_use_case: Arc::new(http_api::icon::use_case::IconUseCase {
+            icon_repository: Arc::new(http_api::icon::repository::IconRepositoryStub),
+        }),
+    });
+    http_api::icon::controller::router::icon_router(state).0
+}
+
+#[tokio::test]
+async fn icon_list_returns_stub_icons() {
+    let (status, json) = get_json(icon_test_router(), "/api/v1/icon").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json.as_array().unwrap().len(), 2);
+    assert_eq!(json[0]["id"], "icon-1");
+    assert_eq!(json[0]["content_type"], "image/png");
+}
+
+// ---- image ----
+
+fn image_test_router() -> axum::Router {
+    let state = Arc::new(http_api::image::controller::router::ImageState {
+        image_use_case: Arc::new(http_api::image::use_case::ImageUseCase {
+            repository: Arc::new(http_api::image::repository::ImageRepositoryStub),
+        }),
+    });
+    http_api::image::controller::router::image_router(state).0
+}
+
+#[tokio::test]
+async fn image_fetch_returns_stub_image() {
+    let (status, json) = get_json(image_test_router(), "/api/v1/image").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["images"][0]["title"], "alpha");
+}
+
+#[tokio::test]
+async fn image_tags_returns_stub_tag() {
+    let (status, json) = get_json(image_test_router(), "/api/v1/image/tag").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json[0]["tag_name"], "artist-tag");
+}
+
+// ---- to_do ----
+
+fn to_do_test_router() -> axum::Router {
+    let state = Arc::new(http_api::to_do::controller::router::ToDoState {
+        to_do_use_case: Arc::new(http_api::to_do::use_case::ToDoUseCase {
+            to_do_repository: Arc::new(http_api::to_do::repository::ToDoRepositoryStub),
+        }),
+    });
+    http_api::to_do::controller::router::to_do_router(state).0
+}
+
+#[tokio::test]
+async fn to_do_list_returns_array() {
+    let (status, json) = get_json(to_do_test_router(), "/api/v1/to-do").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let rows = json.as_array().unwrap();
+    assert!(!rows.is_empty());
+    assert!(rows[0]["title"].is_string());
+}
+
+// ---- trivia ----
+
+fn trivia_test_router() -> axum::Router {
+    let state = Arc::new(http_api::trivia::controller::router::TriviaState {
+        trivia_use_case: Arc::new(http_api::trivia::use_case::TriviaUseCase {
+            trivia_repository: Arc::new(http_api::trivia::repository::TriviaRepositoryStub),
+        }),
+    });
+    http_api::trivia::controller::router::trivia_router(state).0
+}
+
+#[tokio::test]
+async fn trivia_list_returns_array() {
+    let (status, json) = get_json(trivia_test_router(), "/api/v1/trivia").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json.as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn trivia_block_list_normalizes_root() {
+    let (status, json) = get_json(trivia_test_router(), "/api/v1/trivia/block/any-id").await;
+
+    assert_eq!(status, StatusCode::OK);
+    // The renderer resolves the root by the hardcoded id "root".
+    assert_eq!(json["surface"]["root"], "root");
+}
+
+// ---- typing ----
+
+fn typing_test_router() -> axum::Router {
+    let state = Arc::new(http_api::typing::controller::router::TypingState {
+        typing_use_case: Arc::new(http_api::typing::use_case::TypingUseCase {
+            typing_repository: Arc::new(http_api::typing::repository::TypingRepositoryStub),
+        }),
+    });
+    http_api::typing::controller::router::typing_router(state).0
+}
+
+#[tokio::test]
+async fn typing_list_returns_stub_rows() {
+    let (status, json) = get_json(typing_test_router(), "/api/v1/typing").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json.as_array().unwrap().len(), 2);
+    assert_eq!(json[0]["id"], "93165a44-43c8-4790-84ad-08de54ec549a");
+}
+
+#[tokio::test]
+async fn typing_upsert_returns_ok() {
+    let response = typing_test_router()
+        .oneshot(
+            Request::post("/api/v1/typing")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"text":"hello","description":"d"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["id"], "680008c4-d898-4202-8102-137cd9256595");
+}
+
+#[tokio::test]
+async fn typing_unknown_path_is_404() {
+    let (status, _) = get_json(typing_test_router(), "/api/v1/nope").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
Adds the in-process **API/wiring** test tier discussed in the layered-testing design: boot the real Axum router / GraphQL schema with **stub-backed use_cases** and drive them via `tower::oneshot`. This covers the layers the use_case unit tests don't reach — routing, extractors, response serialization, error→status mapping, and `ctx.data::<Arc<UseCase>>()` resolver injection. Fully hermetic (no network/AWS).

## The seam
Each `init_*_router()` previously hardcoded the real `*RepositoryImpl`, leaving no injection point. Split out the pure construction:
- `<feature>_router(state) -> (Router, OpenApi)` on all 7 controller routers.
- `build_schema(anki, bookmark, to_do, typing)` in `schema.rs`.

`init_*` / `try_init_schema` now build real dependencies and delegate — **behavior unchanged**.

## Tests
- **`tests/api_rest.rs`** — 11 tests across all 7 REST features (happy paths + a 404), asserting status codes and JSON bodies produced from the stubs.
- **`tests/api_graphql.rs`** — 4 tests executing `typingList` / `bookmarkList` / `toDoList` against `build_schema`, plus an unknown-field validation-error case.

## Notes
- dev-dependencies: `tower` (with `util` for `oneshot`) + `http-body-util`. Both test-only; no production footprint.
- AuthLayer isn't wired into the router today, so requests aren't auth-gated in these tests (matches production).

## Verification
`just ci` green: fmt clean, clippy clean under `-D warnings`, **65 hermetic tests** (50 unit + 15 API), live tests still ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)