### PR TITLE
refactor(workspace): centralize shared deps and lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,18 @@
 [workspace]
 members = ["crates/*"]
-resolver = "2"
+resolver = "3"
+
+# Versions shared by 2+ crates live here; each crate opts in with
+# `foo.workspace = true` and layers on its own crate-local features.
+[workspace.dependencies]
+aws-config = "1.8.14"
+lambda_runtime = "1.0.1"
+serde = "1.0.228"
+serde_json = "1.0.149"
+thiserror = "2.0.18"
+tokio = "1.49.0"
+
+# Lints applied uniformly across the workspace; each crate opts in with
+# `[lints] workspace = true`.
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(rust_analyzer)'] }

--- a/crates/feed/Cargo.toml
+++ b/crates/feed/Cargo.toml
@@ -7,8 +7,11 @@ edition = "2021"
 fast_html2md = "0.0.61"
 feed-rs = "2.3.1"
 
-lambda_runtime = "1.0.1"
+lambda_runtime.workspace = true
 reqwest = "0.13.3"
-serde = "1"
-thiserror = "2.0.18"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/http_api/Cargo.toml
+++ b/crates/http_api/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2024"
 # add the latest version of a dependency to the list,
 # and it will keep the alphabetic ordering for you.
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(rust_analyzer)'] }
+[lints]
+workspace = true
 
 [dependencies]
 reqwest = { version = "0.13", features = [
@@ -32,16 +32,16 @@ notionrs_types = "0.20.0"
 n2a2ui = "0.1.2"
 n2a2ui-a2ui = "0.1.0"
 indexmap = { version = "2", features = ["serde"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-tokio = { version = "1.49.0", features = ["macros"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros"] }
 url = "2.5.8"
 
-aws-config = "1.8.14"
+aws-config.workspace = true
 aws-sdk-dynamodb = "1.105.0"
 uuid = { version = "1.20.0", features = ["v4"] }
 async-trait = "0.1.89"
-thiserror = "2.0.18"
+thiserror.workspace = true
 log = "0.4.29"
 env_logger = { version = "0.11.9" }
 aws-sdk-ssm = "1.104.0"

--- a/crates/logs-reporter/Cargo.toml
+++ b/crates/logs-reporter/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aws-config = "1.8.14"
+aws-config.workspace = true
 aws-sdk-sns = "1.95.0"
 aws_lambda_events = { version = "1.0.3", default-features = false, features = ["cloudwatch_logs"] }
 
-lambda_runtime = "1.0.1"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-tokio = { version = "1", features = ["macros"] }
+lambda_runtime.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros"] }
+
+[lints]
+workspace = true


### PR DESCRIPTION
## What

Phase 1 of the `http_api` refactor (the test safety net — unit + component tiers, CI, coverage/Codecov — is already in place).

Centralizes the workspace manifest:

- **`[workspace.dependencies]`** — deps used by 2+ crates: `aws-config`, `lambda_runtime`, `serde`, `serde_json`, `thiserror`, `tokio`. Each crate opts in with `foo.workspace = true` and keeps its own feature selection inline (e.g. `tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }` in `feed`, just `["macros"]` elsewhere).
- **`[workspace.lints]`** — the existing `unexpected_cfgs` lint, now uniform; each crate opts in with `[lints] workspace = true`.
- **`resolver = "3"`**.

## Notes

- **`reqwest` left per-crate on purpose**: `feed` uses its default features while `http_api` sets `default-features = false`; Cargo can't express both through one workspace entry.
- **No `rust-toolchain.toml`** — pinning the toolchain is a separate decision, not bundled here.

## Verification

- `cargo build --workspace --all-targets` — clean.
- **`Cargo.lock` unchanged** → dependency resolution is byte-for-byte identical. Pure manifest refactor, no behavior change.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p http-api` — 50 unit + 11 component tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)