### PR TITLE
fix(tts): propagate errors instead of panicking on network/infer

### DIFF
--- a/crates/http_api/src/error.rs
+++ b/crates/http_api/src/error.rs
@@ -9,6 +9,12 @@ pub enum Error {
     #[error("serde error: {0}")]
     SerdeJson(#[from] serde_json::Error),
 
+    #[error("HTTP request error: {0}")]
+    Reqwest(#[from] reqwest::Error),
+
+    #[error("could not infer file type from bytes")]
+    InferUnknownType,
+
     // Boxed: this AWS `SdkError` is ~360 bytes and would otherwise dominate the
     // size of `Error` — and of every enum that wraps it via `#[from]`.
     #[error("SSM SDK error: {0}")]

--- a/crates/http_api/src/tts/repository.rs
+++ b/crates/http_api/src/tts/repository.rs
@@ -39,7 +39,7 @@ impl TtsRepository for TtsRepositoryImpl {
                 .header("x-api-key", secret)
                 .body(body_value.to_string());
 
-            let response = request.send().await.unwrap().bytes().await.unwrap();
+            let response = request.send().await?.error_for_status()?.bytes().await?;
 
             #[derive(Deserialize)]
             struct Response {
@@ -51,11 +51,10 @@ impl TtsRepository for TtsRepositoryImpl {
             let voice = client
                 .get(download_url)
                 .send()
-                .await
-                .unwrap()
+                .await?
+                .error_for_status()?
                 .bytes()
-                .await
-                .unwrap();
+                .await?;
 
             Ok(voice)
         })

--- a/crates/http_api/src/tts/use_case.rs
+++ b/crates/http_api/src/tts/use_case.rs
@@ -5,9 +5,9 @@ pub struct TtsService {
 }
 
 impl TtsService {
-    pub fn infer(&self, buf: bytes::Bytes) -> String {
-        let kind = infer::get(&buf).expect("file type is known");
-        kind.mime_type().to_owned()
+    pub fn infer(&self, buf: bytes::Bytes) -> Result<String, crate::error::Error> {
+        let kind = infer::get(&buf).ok_or(crate::error::Error::InferUnknownType)?;
+        Ok(kind.mime_type().to_owned())
     }
 
     pub async fn text_to_speach(&self, text: &str) -> Result<bytes::Bytes, crate::error::Error> {
@@ -42,6 +42,22 @@ mod tests {
         // 8-byte PNG signature — enough for `infer` to classify the bytes.
         let png = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\n");
 
-        assert_eq!(service.infer(png), "image/png");
+        assert_eq!(service.infer(png).unwrap(), "image/png");
+    }
+
+    #[test]
+    fn infer_unknown_bytes_is_error() {
+        let service = TtsService {
+            tts_repository: Arc::new(TtsRepositoryStub),
+        };
+
+        // Bytes with no recognizable magic number → `InferUnknownType`,
+        // not a panic.
+        let unknown = bytes::Bytes::from_static(b"not a known file type");
+
+        assert!(matches!(
+            service.infer(unknown),
+            Err(crate::error::Error::InferUnknownType)
+        ));
     }
 }


### PR DESCRIPTION
## What

Phase 2 of the `http_api` refactor. Removes the latent panics in the `tts` module.

`TtsRepositoryImpl::text_to_speach` called `.send().await.unwrap().bytes().await.unwrap()` on **two** outbound HTTP requests, and `TtsService::infer` did `infer::get(..).expect("file type is known")`. A network blip, a non-2xx from `ttsapi.fineshare.com`, or an unrecognized byte stream would **panic the Lambda** rather than return an error.

## Changes

- Add `Error::Reqwest` (`#[from] reqwest::Error`) and `Error::InferUnknownType`.
- Replace the four `.unwrap()`s with `?`. Also add `error_for_status()?` so a non-2xx response becomes an error instead of being fed to `serde_json::from_slice` (which would currently fail with an opaque parse error).
- `TtsService::infer` now returns `Result<String, Error>`, mapping the `None` case to `InferUnknownType`.
- New unit test for the unknown-bytes error path.

## Note

`tts` is declared in `lib.rs` but not yet wired into any router/schema, so these panics aren't reachable over HTTP today — this hardens the code before it gets wired up.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p http-api` — all pass (51 unit incl. the new test, 11 component; live tests still ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)