### PR TITLE
refactor(http_api): extract shared controller error response

### DIFF
--- a/crates/http_api/src/anki/controller/mod.rs
+++ b/crates/http_api/src/anki/controller/mod.rs
@@ -17,12 +17,10 @@ pub enum AnkiControllerError {
 
 impl IntoResponse for AnkiControllerError {
     fn into_response(self) -> axum::response::Response {
-        tracing::error!(error = ?self, "request failed");
         let status = match &self {
             Self::UseCase(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        let body = serde_json::json!({ "error": self.to_string() });
-        (status, Json(body)).into_response()
+        crate::error::render_error_response(status, &self)
     }
 }
 

--- a/crates/http_api/src/bookmark/controller/mod.rs
+++ b/crates/http_api/src/bookmark/controller/mod.rs
@@ -17,12 +17,10 @@ pub enum BookmarkControllerError {
 
 impl IntoResponse for BookmarkControllerError {
     fn into_response(self) -> axum::response::Response {
-        tracing::error!(error = ?self, "request failed");
         let status = match &self {
             Self::UseCase(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        let body = serde_json::json!({ "error": self.to_string() });
-        (status, Json(body)).into_response()
+        crate::error::render_error_response(status, &self)
     }
 }
 

--- a/crates/http_api/src/error.rs
+++ b/crates/http_api/src/error.rs
@@ -34,3 +34,19 @@ impl From<aws_sdk_ssm::error::SdkError<aws_sdk_ssm::operation::get_parameter::Ge
         Error::SsmSdkError(Box::new(value))
     }
 }
+
+/// Renders a controller error as the crate's standard JSON error response:
+/// logs it at `error` level and returns `{ "error": <Display> }` with the
+/// given status. Every feature's `IntoResponse` impl delegates here so the
+/// log line and body shape stay identical in one place; the per-controller
+/// `status` decision stays local to each error type.
+pub fn render_error_response<E>(status: http::StatusCode, error: &E) -> axum::response::Response
+where
+    E: std::fmt::Display + std::fmt::Debug,
+{
+    use axum::response::IntoResponse;
+
+    tracing::error!(error = ?error, "request failed");
+    let body = serde_json::json!({ "error": error.to_string() });
+    (status, axum::Json(body)).into_response()
+}

--- a/crates/http_api/src/icon/controller/mod.rs
+++ b/crates/http_api/src/icon/controller/mod.rs
@@ -16,12 +16,10 @@ pub enum IconControllerError {
 
 impl IntoResponse for IconControllerError {
     fn into_response(self) -> axum::response::Response {
-        tracing::error!(error = ?self, "request failed");
         let status = match &self {
             Self::UseCase(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        let body = serde_json::json!({ "error": self.to_string() });
-        (status, Json(body)).into_response()
+        crate::error::render_error_response(status, &self)
     }
 }
 

--- a/crates/http_api/src/image/controller/mod.rs
+++ b/crates/http_api/src/image/controller/mod.rs
@@ -17,12 +17,10 @@ pub enum ImageControllerError {
 
 impl IntoResponse for ImageControllerError {
     fn into_response(self) -> axum::response::Response {
-        tracing::error!(error = ?self, "request failed");
         let status = match &self {
             Self::UseCase(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        let body = serde_json::json!({ "error": self.to_string() });
-        (status, Json(body)).into_response()
+        crate::error::render_error_response(status, &self)
     }
 }
 

--- a/crates/http_api/src/to_do/controller/mod.rs
+++ b/crates/http_api/src/to_do/controller/mod.rs
@@ -16,12 +16,10 @@ pub enum ToDoControllerError {
 
 impl IntoResponse for ToDoControllerError {
     fn into_response(self) -> axum::response::Response {
-        tracing::error!(error = ?self, "request failed");
         let status = match &self {
             Self::UseCase(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        let body = serde_json::json!({ "error": self.to_string() });
-        (status, Json(body)).into_response()
+        crate::error::render_error_response(status, &self)
     }
 }
 

--- a/crates/http_api/src/trivia/controller/mod.rs
+++ b/crates/http_api/src/trivia/controller/mod.rs
@@ -17,12 +17,10 @@ pub enum TriviaControllerError {
 
 impl IntoResponse for TriviaControllerError {
     fn into_response(self) -> axum::response::Response {
-        tracing::error!(error = ?self, "request failed");
         let status = match &self {
             Self::UseCase(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        let body = serde_json::json!({ "error": self.to_string() });
-        (status, Json(body)).into_response()
+        crate::error::render_error_response(status, &self)
     }
 }
 

--- a/crates/http_api/src/typing/controller/mod.rs
+++ b/crates/http_api/src/typing/controller/mod.rs
@@ -17,12 +17,10 @@ pub enum TypingControllerError {
 
 impl IntoResponse for TypingControllerError {
     fn into_response(self) -> axum::response::Response {
-        tracing::error!(error = ?self, "request failed");
         let status = match &self {
             Self::UseCase(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        let body = serde_json::json!({ "error": self.to_string() });
-        (status, Json(body)).into_response()
+        crate::error::render_error_response(status, &self)
     }
 }
 


### PR DESCRIPTION
## What

Phase 3A of the `http_api` refactor — de-duplicating the error-enum boilerplate.

All 7 feature controllers (`anki`, `bookmark`, `icon`, `image`, `to_do`, `trivia`, `typing`) had a **byte-identical** `IntoResponse` body:

```rust
tracing::error!(error = ?self, "request failed");
let status = match &self {
    Self::UseCase(_) => StatusCode::INTERNAL_SERVER_ERROR,
};
let body = serde_json::json!({ "error": self.to_string() });
(status, Json(body)).into_response()
```

Extracted the identical part into a single helper:

```rust
// crate::error
pub fn render_error_response<E: Display + Debug>(status: StatusCode, error: &E) -> Response
```

Each controller now just computes its `status` and delegates. The log line and JSON body shape now live in **one** place instead of seven.

## Deliberately *not* changed

- The per-controller `status = match &self { ... }` stays **local** to each error type. That's the exact seam a follow-up will use to map specific variants to `4xx`/`5xx`. This PR keeps the uniform `500`.
- The per-layer error enums (`Controller`/`UseCase`/`Repository`) are untouched — they document layer boundaries.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` — clean (no now-unused imports; `Json` is still used by handlers).
- `cargo test -p http-api` — 51 unit + 11 component tests pass. Behavior unchanged: same log, same body, same status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)