### PR TITLE
feat(ag-ui-server): DynamoDB-backed SessionStore for resumable conversations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 name = "internal"
 version = "0.1.0"
 requires-python = ">=3.12"
+dependencies = [
+    "pyright>=1.1.410",
+]
 
 [tool.uv.workspace]
 members = ["python/*"]

--- a/python/ag-ui-server/src/ag_ui_server/agent.py
+++ b/python/ag-ui-server/src/ag_ui_server/agent.py
@@ -27,8 +27,6 @@ KNOWLEDGE_TOOLS = f"mcp__{MCP_SERVER_NAME}"
 # all so the agent can only call the managed Knowledge MCP tools — never the
 # bundled WebSearch/WebFetch, a shell, or the filesystem.
 HIDDEN_BUILTINS = [
-    "WebSearch",
-    "WebFetch",
     "Bash",
     "BashOutput",
     "KillShell",
@@ -68,7 +66,11 @@ def build_agent_options(config: Config) -> ClaudeAgentOptions:
             }
         },
         # The agent may use the Knowledge MCP tools; everything else is hidden.
-        allowed_tools=[KNOWLEDGE_TOOLS],
+        allowed_tools=[
+            KNOWLEDGE_TOOLS,
+            "WebSearch",
+            "WebFetch",
+        ],
         disallowed_tools=HIDDEN_BUILTINS,
         # No on-disk CLAUDE.md / settings exist in the container, but pin to none
         # so the agent stays hermetic regardless of the filesystem.

--- a/python/ag-ui-server/src/ag_ui_server/agent.py
+++ b/python/ag-ui-server/src/ag_ui_server/agent.py
@@ -11,9 +11,14 @@ Knowledge MCP — never run a shell or search the web any other way.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from claude_agent_sdk import ClaudeAgentOptions
 
 from .config import Config
+
+if TYPE_CHECKING:
+    from claude_agent_sdk import SessionStore
 
 # Name we register the MCP server under; the SDK namespaces its tools as
 # ``mcp__<server>__<tool>``.
@@ -50,11 +55,22 @@ When you use search results, cite the source URL inline as [title](url).
 """
 
 
-def build_agent_options(config: Config) -> ClaudeAgentOptions:
+def build_agent_options(
+    config: Config,
+    *,
+    session_store: SessionStore | None = None,
+    session_id: str | None = None,
+    resume: str | None = None,
+) -> ClaudeAgentOptions:
     """Assemble the single-agent configuration as Claude Agent SDK options.
 
     ``include_partial_messages`` is enabled so the agent's text and tool calls
     stream token-by-token, which the AG-UI bridge forwards as incremental events.
+
+    When ``session_store`` is supplied the run is persisted: pass ``session_id``
+    on a conversation's first turn (creates the session) and ``resume`` on later
+    turns (rehydrates history from the store). They are mutually exclusive; all
+    three default to ``None`` (the SDK's stateless behavior).
     """
     return ClaudeAgentOptions(
         model=config.model_id,
@@ -80,4 +96,8 @@ def build_agent_options(config: Config) -> ClaudeAgentOptions:
         # Stream partial assistant/tool deltas (raw Anthropic stream events) so
         # the bridge can emit incremental AG-UI events.
         include_partial_messages=True,
+        # Persistence/resume — all None unless a session store is wired in.
+        session_store=session_store,
+        session_id=session_id,
+        resume=resume,
     )

--- a/python/ag-ui-server/src/ag_ui_server/agui_bridge.py
+++ b/python/ag-ui-server/src/ag_ui_server/agui_bridge.py
@@ -96,7 +96,7 @@ def _translate_stream_event(
         return
 
     if etype == "content_block_start":
-        index = event.get("index")
+        index: int = event["index"]
         block = event.get("content_block") or {}
         block_type = block.get("type")
         if block_type == "text":
@@ -129,7 +129,7 @@ def _translate_stream_event(
         return
 
     if etype == "content_block_delta":
-        entry = blocks.get(event.get("index"))
+        entry = blocks.get(event["index"])
         if entry is None:
             return
         kind, identifier = entry
@@ -163,7 +163,7 @@ def _translate_stream_event(
         return
 
     if etype == "content_block_stop":
-        entry = blocks.pop(event.get("index"), None)
+        entry = blocks.pop(event["index"], None)
         if entry is None:
             return
         kind, identifier = entry

--- a/python/ag-ui-server/src/ag_ui_server/config.py
+++ b/python/ag-ui-server/src/ag_ui_server/config.py
@@ -21,6 +21,12 @@ class Config:
     mcp_url: str
     # Upper bound on agentic turns (tool calls + final answer) per invocation.
     max_turns: int
+    # DynamoDB table that mirrors SDK session transcripts. When unset, the
+    # runtime stays stateless (client-replayed history); when set, sessions are
+    # persisted and resumed server-side. See ``session_store.py``.
+    session_table_name: str | None
+    # Region the session table lives in. Defaults to boto3's resolved region.
+    session_table_region: str | None
 
     @classmethod
     def from_env(cls) -> Config:
@@ -32,6 +38,8 @@ class Config:
             model_id=os.environ.get("MODEL_ID", "claude-sonnet-4-6"),
             mcp_url=os.environ.get("MCP_URL", "https://knowledge-mcp.global.api.aws"),
             max_turns=int(os.environ.get("MAX_TURNS", "20")),
+            session_table_name=os.environ.get("SESSION_TABLE_NAME") or None,
+            session_table_region=os.environ.get("SESSION_TABLE_REGION") or None,
         )
 
 

--- a/python/ag-ui-server/src/ag_ui_server/prompt.py
+++ b/python/ag-ui-server/src/ag_ui_server/prompt.py
@@ -36,6 +36,21 @@ def build_prompt(input_data: RunAgentInput) -> str:
     )
 
 
+def build_latest_user_prompt(input_data: RunAgentInput) -> str:
+    """Build the prompt for a *resumed* session: only the newest user turn.
+
+    When the SDK resumes a session it already holds the prior turns, so resending
+    the whole transcript (as :func:`build_prompt` does) would duplicate history.
+    Send just the latest user message; fall back to the full prompt if none is
+    found.
+    """
+    messages = [m for m in (input_data.messages or []) if _message_text(m).strip()]
+    for message in reversed(messages):
+        if message.role == "user":
+            return _message_text(message) + _context_block(input_data)
+    return build_prompt(input_data)
+
+
 def _context_block(input_data: RunAgentInput) -> str:
     context = input_data.context or []
     if not context:

--- a/python/ag-ui-server/src/ag_ui_server/server.py
+++ b/python/ag-ui-server/src/ag_ui_server/server.py
@@ -15,6 +15,8 @@ import os
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
+from uuid import NAMESPACE_URL, uuid5
 
 from ag_ui.core import (
     EventType,
@@ -33,10 +35,15 @@ from .agent import build_agent_options
 from .agui_bridge import translate
 from .config import Config
 from .model_auth import configure_sdk_env, fetch_oauth_token
-from .prompt import build_prompt
+from .prompt import build_latest_user_prompt, build_prompt
+from .session_store import DynamoDBSessionStore
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+# Fixed namespace for deriving a stable per-thread SDK session id (a valid UUID)
+# from the AG-UI ``thread_id``, so the same conversation always resumes itself.
+_THREAD_NS = uuid5(NAMESPACE_URL, "46ki75/internal/ag-ui-server/thread")
 
 
 @asynccontextmanager
@@ -50,8 +57,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     config = Config.from_env()
     configure_sdk_env(fetch_oauth_token(config))
     app.state.config = config
+    app.state.session_store = (
+        DynamoDBSessionStore(
+            config.session_table_name, region=config.session_table_region
+        )
+        if config.session_table_name
+        else None
+    )
     logger.info(
-        "ag-ui-server ready (model=%s, mcp=%s)", config.model_id, config.mcp_url
+        "ag-ui-server ready (model=%s, mcp=%s, sessions=%s)",
+        config.model_id,
+        config.mcp_url,
+        config.session_table_name or "disabled",
     )
     yield
 
@@ -71,10 +88,38 @@ async def ping() -> JSONResponse:
     return JSONResponse({"status": "Healthy", "time_of_last_update": int(time.time())})
 
 
+def _plan_run(
+    config: Config,
+    store: DynamoDBSessionStore | None,
+    input_data: RunAgentInput,
+) -> tuple[Any, str]:
+    """Choose the SDK options and prompt for one run.
+
+    Stateless (no store): replay the whole client-held transcript. Stateful: key
+    a stable session id off ``thread_id`` and either create it (first turn) or
+    resume it (once the client echoes a prior assistant turn), sending only the
+    newest user message so resumed history isn't duplicated.
+    """
+    if store is None:
+        return build_agent_options(config), build_prompt(input_data)
+
+    session_id = str(uuid5(_THREAD_NS, input_data.thread_id))
+    resuming = any(
+        getattr(message, "role", None) == "assistant"
+        for message in (input_data.messages or [])
+    )
+    if resuming:
+        options = build_agent_options(config, session_store=store, resume=session_id)
+        return options, build_latest_user_prompt(input_data)
+    options = build_agent_options(config, session_store=store, session_id=session_id)
+    return options, build_prompt(input_data)
+
+
 @app.post("/invocations")
 async def invocations(input_data: RunAgentInput, request: Request) -> StreamingResponse:
     """Run the agent for one AG-UI run and stream the result as SSE events."""
     config: Config = request.app.state.config
+    store: DynamoDBSessionStore | None = request.app.state.session_store
     encoder = EventEncoder(accept=request.headers.get("accept") or "")
 
     async def event_generator() -> AsyncIterator[str]:
@@ -86,8 +131,7 @@ async def invocations(input_data: RunAgentInput, request: Request) -> StreamingR
             )
         )
         try:
-            options = build_agent_options(config)
-            prompt = build_prompt(input_data)
+            options, prompt = _plan_run(config, store, input_data)
             async for event in translate(query(prompt=prompt, options=options)):
                 yield encoder.encode(event)
             yield encoder.encode(

--- a/python/ag-ui-server/src/ag_ui_server/server.py
+++ b/python/ag-ui-server/src/ag_ui_server/server.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 
 from ag_ui.core import (
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Load config and authenticate the SDK once at startup.
 
     The OAuth token is read from SSM and exported before the first ``query()``,
@@ -75,7 +75,7 @@ async def ping() -> JSONResponse:
 async def invocations(input_data: RunAgentInput, request: Request) -> StreamingResponse:
     """Run the agent for one AG-UI run and stream the result as SSE events."""
     config: Config = request.app.state.config
-    encoder = EventEncoder(accept=request.headers.get("accept"))
+    encoder = EventEncoder(accept=request.headers.get("accept") or "")
 
     async def event_generator() -> AsyncIterator[str]:
         yield encoder.encode(

--- a/python/ag-ui-server/src/ag_ui_server/session_store.py
+++ b/python/ag-ui-server/src/ag_ui_server/session_store.py
@@ -1,0 +1,250 @@
+# boto3's resource API and the SDK's TypedDict session types are dynamically
+# typed, so this module opts down to basic type checking.
+# pyright: basic
+"""A DynamoDB-backed :class:`~claude_agent_sdk.SessionStore`.
+
+The Claude Agent SDK mirrors each session's transcript (one JSONL line per
+``SessionStoreEntry``) to this adapter via :meth:`append`, and rehydrates a
+session for ``resume`` via :meth:`load`. Subagent transcripts arrive under the
+same session with a ``subpath`` and are discoverable through :meth:`list_subkeys`.
+
+Storage model — one DynamoDB item per transcript entry:
+
+- ``pk`` = ``"<project_key>#<session_id>"`` — one partition per session, so
+  the whole session (main transcript + every subagent ``subpath``) lives
+  together: :meth:`list_subkeys` and the cascade in :meth:`delete` are a single
+  ``Query``/scan of that partition.
+- ``sk`` = ``"<subpath>#<order>#<kind>#<id>"``. ``order`` is a zero-padded
+  counter placed first so a Query returns a subpath's entries already in append
+  order, and the next counter value is a single descending ``Limit=1`` read — no
+  full scan as the transcript grows. ``kind`` is ``u`` for an entry with a stable
+  ``uuid`` (``id`` = that uuid, so a re-append overwrites itself — idempotent) or
+  ``n`` for one without (``id`` = random hex, never deduped, per the contract).
+  ``#`` is the conventional single-table delimiter and can't occur in any
+  component here (``session_id``/``uuid`` are UUIDs, ``project_key`` is the fixed
+  container cwd, ``subpath`` is SDK-controlled), so prefix queries are
+  unambiguous. ``order`` is also kept as an attribute for readability and a
+  backend-agnostic sort on :meth:`load`.
+
+The SDK guarantees the local-disk transcript is already durable before calling
+:meth:`append`, so a failed mirror is non-fatal (it retries, then surfaces a
+``MirrorErrorMessage``). Retention is ours: items carry a ``ttl`` attribute for
+DynamoDB TTL. This is an experimental, single-runtime store — concurrent writers
+to the *same* session would race the order counter; that doesn't happen with one
+runtime per session.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+import boto3
+from anyio.to_thread import run_sync
+from boto3.dynamodb.conditions import Key
+from claude_agent_sdk import SessionStore
+
+if TYPE_CHECKING:
+    from claude_agent_sdk import (
+        SessionKey,
+        SessionListSubkeysKey,
+        SessionStoreEntry,
+        SessionStoreListEntry,
+        SessionSummaryEntry,
+    )
+
+# Composite-key delimiter — the DynamoDB single-table idiom. Safe because no key
+# component contains it: session_id/uuid are UUIDs, project_key is the fixed
+# container cwd, and subpath is SDK-controlled (``subagents/…``). Keeps the keys
+# legible in the console (the whole point of this observability-focused store).
+_SEP = "#"
+
+
+class DynamoDBSessionStore(SessionStore):
+    """Mirror Claude Agent SDK session transcripts to a DynamoDB table."""
+
+    def __init__(
+        self,
+        table_name: str,
+        *,
+        table: Any | None = None,
+        region: str | None = None,
+        ttl_days: int = 30,
+    ) -> None:
+        # ``table`` is injectable so tests can substitute the three primitives
+        # below without standing up DynamoDB.
+        if table is None:
+            resource: Any = boto3.resource("dynamodb", region_name=region)
+            table = resource.Table(table_name)
+        self._table: Any = table
+        self._ttl_days = ttl_days
+        self._lock = threading.Lock()
+        # (pk, subpath) -> {"next": int, "uuids": {uuid: order}} — seeded lazily
+        # from the store (next counter via one O(1) read; uuids fills in-process).
+        self._order: dict[str, dict[str, Any]] = {}
+
+    # --- required methods -------------------------------------------------
+
+    async def append(
+        self, key: SessionKey, entries: list[SessionStoreEntry]
+    ) -> None:
+        await run_sync(self._append_sync, key, entries)
+
+    async def load(self, key: SessionKey) -> list[SessionStoreEntry] | None:
+        return await run_sync(self._load_sync, key)
+
+    # --- optional methods -------------------------------------------------
+
+    async def list_subkeys(self, key: SessionListSubkeysKey) -> list[str]:
+        return await run_sync(self._list_subkeys_sync, key)
+
+    async def delete(self, key: SessionKey) -> None:
+        await run_sync(self._delete_sync, key)
+
+    # This store powers resume, not session browsing, so the listing methods are
+    # left unimplemented (the SessionStore protocol still requires them to exist;
+    # the conformance suite skips them via ``skip_optional``).
+    async def list_sessions(self, project_key: str) -> list[SessionStoreListEntry]:
+        raise NotImplementedError
+
+    async def list_session_summaries(
+        self, project_key: str
+    ) -> list[SessionSummaryEntry]:
+        raise NotImplementedError
+
+    # --- synchronous implementations (run in a worker thread) -------------
+
+    def _append_sync(
+        self, key: SessionKey, entries: list[SessionStoreEntry]
+    ) -> None:
+        pk = self._pk(key)
+        subpath = key.get("subpath") or ""
+        cache_key = f"{pk}{_SEP}{subpath}"
+        now_ttl = int(time.time()) + self._ttl_days * 86400 if self._ttl_days else 0
+
+        items: list[dict[str, Any]] = []
+        with self._lock:
+            state = self._order.get(cache_key) or self._seed_order(pk, subpath)
+            self._order[cache_key] = state
+            for entry in entries:
+                uid = entry.get("uuid") or None
+                if uid is not None and uid in state["uuids"]:
+                    order = state["uuids"][uid]
+                else:
+                    order = state["next"]
+                    state["next"] += 1
+                    if uid is not None:
+                        state["uuids"][uid] = order
+                item: dict[str, Any] = {
+                    "pk": pk,
+                    "sk": self._sk(subpath, order, uid),
+                    "subpath": subpath,
+                    "order": order,
+                    "body": json.dumps(entry, ensure_ascii=False),
+                }
+                if uid is not None:
+                    item["uuid"] = uid
+                if now_ttl:
+                    item["ttl"] = now_ttl
+                items.append(item)
+        self._put_batch(items)
+
+    def _load_sync(self, key: SessionKey) -> list[SessionStoreEntry] | None:
+        pk = self._pk(key)
+        subpath = key.get("subpath") or ""
+        items = self._query(pk, f"{subpath}{_SEP}")
+        if not items:
+            return None
+        items.sort(key=lambda it: int(it["order"]))
+        return [json.loads(it["body"]) for it in items]
+
+    def _list_subkeys_sync(self, key: SessionListSubkeysKey) -> list[str]:
+        pk = self._pk(key)
+        subpaths = {
+            sp for it in self._query(pk, None) if (sp := it.get("subpath") or "")
+        }
+        return sorted(subpaths)
+
+    def _delete_sync(self, key: SessionKey) -> None:
+        pk = self._pk(key)
+        subpath = key.get("subpath")
+        # A targeted subpath delete removes only that transcript; a main-key
+        # delete (no subpath) cascades to every subkey in the partition.
+        prefix = f"{subpath}{_SEP}" if subpath else None
+        items = self._query(pk, prefix)
+        self._delete_keys([(it["pk"], it["sk"]) for it in items])
+        with self._lock:
+            if subpath:
+                self._order.pop(f"{pk}{_SEP}{subpath}", None)
+            else:
+                for ck in [k for k in self._order if k.startswith(f"{pk}{_SEP}")]:
+                    self._order.pop(ck, None)
+
+    # --- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _pk(key: SessionKey | SessionListSubkeysKey) -> str:
+        return f"{key['project_key']}{_SEP}{key['session_id']}"
+
+    @staticmethod
+    def _sk(subpath: str, order: int, uid: str | None) -> str:
+        # uuid-keyed suffix → a re-append (same uuid, same cached order) yields
+        # the same sk and overwrites in place; no-uuid entries get a random id so
+        # they always append (never dedup), per the contract.
+        suffix = f"u{_SEP}{uid}" if uid else f"n{_SEP}{uuid4().hex}"
+        return f"{subpath}{_SEP}{order:020d}{_SEP}{suffix}"
+
+    def _seed_order(self, pk: str, subpath: str) -> dict[str, Any]:
+        """Resume the order counter from the store with one O(1) read.
+
+        ``order`` is the first sortable sort-key component, so the highest
+        existing order is just the last item under the subpath prefix. The
+        uuid→order map starts empty: across a restart the SDK only appends *new*
+        entries (it never re-appends an already-stored uuid), so we need the next
+        counter value, not the full dedup map — which keeps this O(1) rather than
+        a full transcript scan on every cold turn.
+        """
+        last = self._query_last(pk, f"{subpath}{_SEP}")
+        return {"next": int(last["order"]) + 1 if last else 0, "uuids": {}}
+
+    # --- DynamoDB primitives (the only AWS-touching code; overridden in tests)
+
+    def _put_batch(self, items: list[dict[str, Any]]) -> None:
+        # overwrite_by_pkeys collapses duplicate (pk, sk) within one batch so a
+        # uuid repeated in a single append doesn't trip BatchWriteItem.
+        with self._table.batch_writer(overwrite_by_pkeys=["pk", "sk"]) as writer:
+            for item in items:
+                writer.put_item(Item=item)
+
+    def _query(self, pk: str, sk_prefix: str | None) -> list[dict[str, Any]]:
+        condition = Key("pk").eq(pk)
+        if sk_prefix is not None:
+            condition = condition & Key("sk").begins_with(sk_prefix)
+        items: list[dict[str, Any]] = []
+        kwargs: dict[str, Any] = {"KeyConditionExpression": condition}
+        while True:
+            response = self._table.query(**kwargs)
+            items.extend(response.get("Items", []))
+            start_key = response.get("LastEvaluatedKey")
+            if not start_key:
+                return items
+            kwargs["ExclusiveStartKey"] = start_key
+
+    def _query_last(self, pk: str, sk_prefix: str) -> dict[str, Any] | None:
+        # Highest sk under the prefix = highest order (it leads the sort key).
+        condition = Key("pk").eq(pk) & Key("sk").begins_with(sk_prefix)
+        response = self._table.query(
+            KeyConditionExpression=condition, ScanIndexForward=False, Limit=1
+        )
+        items = response.get("Items", [])
+        return items[0] if items else None
+
+    def _delete_keys(self, keys: list[tuple[str, str]]) -> None:
+        if not keys:
+            return
+        with self._table.batch_writer() as writer:
+            for pk, sk in keys:
+                writer.delete_item(Key={"pk": pk, "sk": sk})

--- a/python/ag-ui-server/tests/test_agui_bridge.py
+++ b/python/ag-ui-server/tests/test_agui_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any
 
 import anyio
@@ -17,7 +18,7 @@ def _stream(event: dict[str, Any]) -> StreamEvent:
 
 
 def _collect(messages: list[Any]) -> list[Any]:
-    async def _aiter() -> Any:
+    async def _aiter() -> AsyncIterator[Any]:
         for message in messages:
             yield message
 

--- a/python/ag-ui-server/tests/test_prompt.py
+++ b/python/ag-ui-server/tests/test_prompt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ag_ui.core import AssistantMessage, Context, RunAgentInput, UserMessage
 
-from ag_ui_server.prompt import build_prompt
+from ag_ui_server.prompt import build_latest_user_prompt, build_prompt
 
 
 def _input(messages: list, context: list | None = None) -> RunAgentInput:
@@ -51,3 +51,33 @@ def test_multi_turn_renders_transcript() -> None:
     assert "assistant: First answer" in prompt
     assert "user: Follow-up" in prompt
     assert "Respond to the most recent user message." in prompt
+
+
+def test_latest_user_prompt_sends_only_newest_turn() -> None:
+    # On a resumed session the SDK already holds prior turns, so only the newest
+    # user message is sent — no transcript, no earlier turns.
+    prompt = build_latest_user_prompt(
+        _input(
+            [
+                UserMessage(id="1", role="user", content="First question"),
+                AssistantMessage(id="2", role="assistant", content="First answer"),
+                UserMessage(id="3", role="user", content="Follow-up"),
+            ]
+        )
+    )
+    assert prompt == "Follow-up"
+
+
+def test_latest_user_prompt_appends_context() -> None:
+    prompt = build_latest_user_prompt(
+        _input(
+            [
+                UserMessage(id="1", role="user", content="First"),
+                AssistantMessage(id="2", role="assistant", content="Answer"),
+                UserMessage(id="3", role="user", content="Second"),
+            ],
+            context=[Context(description="locale", value="en-US")],
+        )
+    )
+    assert "Second" in prompt
+    assert "locale: en-US" in prompt

--- a/python/ag-ui-server/tests/test_session_store.py
+++ b/python/ag-ui-server/tests/test_session_store.py
@@ -1,0 +1,116 @@
+"""Tests for the DynamoDB-backed SessionStore.
+
+Runs the Claude Agent SDK's own conformance suite plus focused checks for the
+behaviors we most care to observe (ordering, idempotency, subagent isolation,
+cascade delete). The three DynamoDB primitives are overridden with an in-memory
+dict so no AWS is touched; all the adapter's key/order/dedup logic still runs.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Any
+
+import anyio
+from claude_agent_sdk.testing.session_store_conformance import (
+    run_session_store_conformance,
+)
+
+from ag_ui_server.session_store import DynamoDBSessionStore
+
+if TYPE_CHECKING:
+    from claude_agent_sdk import SessionKey
+
+
+def _entries(*items: dict[str, Any]) -> Any:
+    """Build a transcript-entry list (SessionStoreEntry allows opaque keys)."""
+    return list(items)
+
+
+class _InMemoryStore(DynamoDBSessionStore):
+    """A DynamoDBSessionStore whose storage primitives live in a dict."""
+
+    def __init__(self) -> None:
+        self._table = None
+        self._ttl_days = 0
+        self._lock = threading.Lock()
+        self._order = {}
+        self._items: dict[tuple[str, str], dict[str, Any]] = {}
+
+    def _put_batch(self, items: list[dict[str, Any]]) -> None:
+        for item in items:
+            self._items[(item["pk"], item["sk"])] = dict(item)
+
+    def _query(self, pk: str, sk_prefix: str | None) -> list[dict[str, Any]]:
+        return [
+            dict(item)
+            for (item_pk, sk), item in self._items.items()
+            if item_pk == pk and (sk_prefix is None or sk.startswith(sk_prefix))
+        ]
+
+    def _query_last(self, pk: str, sk_prefix: str) -> dict[str, Any] | None:
+        matches = self._query(pk, sk_prefix)
+        return max(matches, key=lambda item: item["sk"]) if matches else None
+
+    def _delete_keys(self, keys: list[tuple[str, str]]) -> None:
+        for key in keys:
+            self._items.pop(key, None)
+
+
+def test_session_store_conformance() -> None:
+    async def _run() -> None:
+        await run_session_store_conformance(
+            _InMemoryStore,
+            skip_optional=frozenset({"list_sessions", "list_session_summaries"}),
+        )
+
+    anyio.run(_run)
+
+
+def test_roundtrip_idempotency_and_order() -> None:
+    store = _InMemoryStore()
+    key: SessionKey = {"project_key": "p", "session_id": "s"}
+    first: Any = {"type": "user", "uuid": "u1", "message": {"content": "hi"}}
+    second: Any = {"type": "assistant", "uuid": "u2", "message": {"content": "yo"}}
+
+    anyio.run(store.append, key, [first])
+    anyio.run(store.append, key, [second])
+    # Re-append the first entry (a mirror retry): must not duplicate or reorder.
+    anyio.run(store.append, key, [first])
+
+    assert anyio.run(store.load, key) == [first, second]
+
+
+def test_subagent_isolation_and_subkeys() -> None:
+    store = _InMemoryStore()
+    main: SessionKey = {"project_key": "p", "session_id": "s"}
+    sub: SessionKey = {"project_key": "p", "session_id": "s", "subpath": "subagents/a"}
+
+    anyio.run(store.append, main, _entries({"type": "user", "uuid": "m1"}))
+    anyio.run(store.append, sub, _entries({"type": "user", "uuid": "a1"}))
+
+    assert anyio.run(store.list_subkeys, main) == ["subagents/a"]
+    # The main transcript load must not pick up subagent entries, and vice versa.
+    loaded_main: Any = anyio.run(store.load, main)
+    loaded_sub: Any = anyio.run(store.load, sub)
+    assert [e["uuid"] for e in loaded_main] == ["m1"]
+    assert [e["uuid"] for e in loaded_sub] == ["a1"]
+
+
+def test_delete_main_cascades_to_subagents() -> None:
+    store = _InMemoryStore()
+    main: SessionKey = {"project_key": "p", "session_id": "s"}
+    sub: SessionKey = {"project_key": "p", "session_id": "s", "subpath": "a"}
+
+    anyio.run(store.append, main, _entries({"type": "x", "uuid": "m1"}))
+    anyio.run(store.append, sub, _entries({"type": "x", "uuid": "a1"}))
+    anyio.run(store.delete, main)
+
+    assert anyio.run(store.load, main) is None
+    assert anyio.run(store.load, sub) is None
+
+
+def test_load_missing_session_returns_none() -> None:
+    store = _InMemoryStore()
+    missing: SessionKey = {"project_key": "p", "session_id": "missing"}
+    assert anyio.run(store.load, missing) is None

--- a/terraform/bedrock-agentcore.tf
+++ b/terraform/bedrock-agentcore.tf
@@ -134,6 +134,18 @@ resource "aws_iam_policy" "bedrock_agentcore_runtime_ag_ui_server" {
             "kms:ViaService" = "ssm.ap-northeast-1.amazonaws.com"
           }
         }
+      },
+      {
+        # Mirror/resume Claude Agent SDK session transcripts in the session table.
+        Sid    = "SessionStore"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:Query",
+          "dynamodb:BatchWriteItem",
+          "dynamodb:PutItem",
+          "dynamodb:DeleteItem"
+        ]
+        Resource = [aws_dynamodb_table.ag-ui-session.arn]
       }
     ]
   })
@@ -189,6 +201,10 @@ resource "aws_bedrockagentcore_agent_runtime" "ag-ui-server" {
     "CLAUDE_CODE_OAUTH_TOKEN_REGION" = "ap-northeast-1"
     "MODEL_ID"                       = "claude-sonnet-4-6"
     "MCP_URL"                        = "https://knowledge-mcp.global.api.aws"
+    # Setting this turns on server-side session persistence/resume (experimental).
+    # Unset it to fall back to the stateless, client-replayed history path.
+    "SESSION_TABLE_NAME"   = aws_dynamodb_table.ag-ui-session.name
+    "SESSION_TABLE_REGION" = "ap-northeast-1"
   }
 
   # The container reads the model secret from SSM at startup, so the execution

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -23,3 +23,30 @@ resource "aws_dynamodb_table" "default" {
 
   deletion_protection_enabled = true
 }
+
+# Mirrors Claude Agent SDK session transcripts for the ag-ui-server runtime so
+# conversations (and subagent transcripts) can be resumed server-side. One item
+# per transcript entry; pk = "<project_key>\x1f<session_id>" groups a whole
+# session in one partition. Experimental: on-demand billing, TTL-swept, no
+# deletion protection. See python/ag-ui-server/src/ag_ui_server/session_store.py.
+resource "aws_dynamodb_table" "ag-ui-session" {
+  name         = "${terraform.workspace}-46ki75-internal-dynamodb-table-ag-ui-session"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "pk"
+  range_key    = "sk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1032,6 +1032,12 @@ wheels = [
 name = "internal"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "pyright" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyright", specifier = ">=1.1.410" }]
 
 [[package]]
 name = "jinja2"
@@ -1439,6 +1445,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
 ]
 
 [[package]]
@@ -1925,6 +1940,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.410"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds server-side conversation persistence to `python/ag-ui-server` (Claude Agent SDK over AG-UI, on Bedrock AgentCore). The Agent SDK mirrors each session's transcript to a DynamoDB-backed `SessionStore`, so a thread **resumes** server-side on the next turn instead of replaying the full client-held history every time.

This branch also includes an earlier commit enabling `WebSearch`/`WebFetch` for the agent.

## How it works

- **`session_store.py` — `DynamoDBSessionStore`**: one DynamoDB item per transcript entry.
  - `pk = <project_key>#<session_id>` — one partition per session, so `list_subkeys` and the `delete` cascade (main transcript + every subagent `subpath`) are a single query.
  - `sk = <subpath>#<order>#<kind>#<id>` — `order` leads the sort key, so a `load` returns entries already ordered and the next counter is an **O(1)** descending `Limit=1` read (no full scan as the transcript grows). `kind=u` entries are keyed by `uuid` → a re-append overwrites itself (idempotent mirror retry); `kind=n` entries get a random id (never deduped, per the contract).
  - Items carry a `ttl` attribute for DynamoDB TTL retention.
  - Passes the Claude Agent SDK's own `run_session_store_conformance` suite (listing methods skipped — this store powers resume, not browsing).
- **`server.py`**: derives a stable `session_id` from `thread_id` via `uuid5`, resumes when the thread already has assistant turns, otherwise runs a fresh stateless turn.
- **`prompt.py`**: `build_latest_user_prompt` sends only the newest user turn on resume (the SDK already holds prior turns).
- **`config.py`**: `SESSION_TABLE_NAME` / `SESSION_TABLE_REGION` env flags.
- **Terraform**: `ag-ui-session` table (PAY_PER_REQUEST + TTL), IAM statement (`Query`/`BatchWriteItem`/`PutItem`/`DeleteItem` scoped to the table), and runtime env wiring.

## Flag-gated

With `SESSION_TABLE_NAME` unset the server falls back to the existing stateless, client-replayed history path — so this is safe to ship dark.

## Testing

- `uv run pyright python/ag-ui-server` → 0 errors
- `uv run --package ag-ui-server pytest python/ag-ui-server/tests` → 16 passed (incl. SDK conformance, idempotency/order, subagent isolation, cascade delete)
- Deployed to **dev** and verified end-to-end against the live table (runtime `READY`, items land with the expected keys/order).

> Note: this is an experimental, single-runtime store — concurrent writers to the *same* session would race the order counter, which doesn't happen with one AgentCore runtime per session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)