### PR TITLE
chore: lefthook pre-commit/fmt/check + Rust 2024 edition + Claude Code hooks

### DIFF
--- a/.claude/hooks/lefthook-check.sh
+++ b/.claude/hooks/lefthook-check.sh
@@ -26,12 +26,16 @@ for f in "${files[@]}"; do
 done
 [ ${#args[@]} -eq 0 ] && exit 0
 
-output=$(NO_COLOR=1 pnpm exec lefthook run check "${args[@]}" 2>&1)
+# `output: false` in lefthook.yml keeps this quiet on success and limits a
+# failure to just the failing command's output (no banner/summary/ANSI).
+raw=$(NO_COLOR=1 pnpm exec lefthook run check "${args[@]}" 2>&1)
 status=$?
-output=$(printf '%s' "$output" | sed -E 's/\x1b\[[0-9;]*m//g')
+[ "$status" -eq 0 ] && exit 0
 
-if [ "$status" -ne 0 ]; then
-  jq -n --arg r "$output" \
-    '{decision: "block", reason: ("`lefthook run check` failed — fix these before stopping:\n\n" + $r)}'
-fi
+# Strip any ANSI a tool emitted on its own; never block with an empty reason.
+raw=$(printf '%s' "$raw" | sed -E 's/\x1b\[[0-9;]*m//g')
+[ -n "${raw//[$' \t\n']/}" ] || raw="lefthook run check exited $status"
+
+jq -n --arg r "$raw" \
+  '{decision: "block", reason: ("`lefthook run check` failed — fix these before stopping:\n\n" + $r)}'
 exit 0

--- a/.claude/hooks/lefthook-check.sh
+++ b/.claude/hooks/lefthook-check.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Claude Code Stop hook: run lefthook's `check` command over the files changed
+# in the working tree. On failure, block the stop and feed the output back so
+# Claude fixes the issues. `stop_hook_active` guards against an infinite loop:
+# the second time we're invoked (because we blocked once), we just allow stop.
+set -uo pipefail
+
+input=$(cat)
+active=$(printf '%s' "$input" | jq -r '.stop_hook_active // false')
+[ "$active" = "true" ] && exit 0
+
+proj="${CLAUDE_PROJECT_DIR:-$PWD}"
+cd "$proj" || exit 0
+
+# Changed (added/modified, not deleted) + untracked files vs HEAD.
+mapfile -t files < <(
+  {
+    git diff --name-only --diff-filter=d HEAD
+    git ls-files --others --exclude-standard
+  } 2>/dev/null | sort -u
+)
+
+args=()
+for f in "${files[@]}"; do
+  [ -n "$f" ] && args+=(--file "$f")
+done
+[ ${#args[@]} -eq 0 ] && exit 0
+
+output=$(NO_COLOR=1 pnpm exec lefthook run check "${args[@]}" 2>&1)
+status=$?
+output=$(printf '%s' "$output" | sed -E 's/\x1b\[[0-9;]*m//g')
+
+if [ "$status" -ne 0 ]; then
+  jq -n --arg r "$output" \
+    '{decision: "block", reason: ("`lefthook run check` failed — fix these before stopping:\n\n" + $r)}'
+fi
+exit 0

--- a/.claude/hooks/lefthook-fmt.sh
+++ b/.claude/hooks/lefthook-fmt.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Claude Code PostToolUse hook (Edit|Write): format the file that was just
+# edited via lefthook's `fmt` command. Non-blocking and quiet on success.
+set -uo pipefail
+
+input=$(cat)
+file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+[ -n "$file" ] || exit 0
+
+proj="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# Only format files inside this repo (Edit may target other working dirs).
+case "$file" in
+  "$proj"/*) ;;
+  *) exit 0 ;;
+esac
+
+cd "$proj" || exit 0
+
+# lefthook scopes to jobs whose glob matches; a non-matching file is a no-op.
+NO_COLOR=1 pnpm exec lefthook run fmt --file "$file" >/dev/null 2>&1 || true
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lefthook-fmt.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lefthook-check.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,10 @@ Stages are `dev` | `stg` | `prod` and are passed via `STAGE_NAME` (Rust/server) 
 
 ## Common commands
 
+### Git hooks (lefthook)
+
+`lefthook.yml` defines a `pre-commit` hook that auto-formats staged files and re-stages the fixes (`stage_fixed`): `cargo fmt --all` for Rust, Prettier for `packages/web-qwik/src`, and `markdownlint-cli2 --fix` for Markdown. Hooks install on `pnpm install` (root `prepare` → `lefthook install`). Heavier gates (clippy, tests, typecheck) stay in CI. Run manually with `pnpm exec lefthook run pre-commit`; bypass once with `git commit --no-verify`.
+
 ### `crates/http-api` (main API Lambda)
 
 The `http-api` binary assembles the per-feature router crates into one Axum app. Per-crate recipes use [`just`](https://github.com/casey/just):

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 members = ["crates/*"]
 resolver = "3"
 
+# Package fields shared by every crate; each crate opts in with
+# `edition.workspace = true`. Keeps the edition unified across the workspace.
+[workspace.package]
+edition = "2024"
+
 # Versions shared by 2+ crates live here; each crate opts in with
 # `foo.workspace = true` and layers on its own crate-local features.
 [workspace.dependencies]

--- a/crates/feed/Cargo.toml
+++ b/crates/feed/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "feed"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 fast_html2md = "0.0.61"

--- a/crates/feed/src/main.rs
+++ b/crates/feed/src/main.rs
@@ -1,4 +1,4 @@
-use lambda_runtime::{run, service_fn, tracing, Error};
+use lambda_runtime::{Error, run, service_fn, tracing};
 mod generic_handler;
 use generic_handler::function_handler;
 

--- a/crates/http-api-anki/Cargo.toml
+++ b/crates/http-api-anki/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-api-anki"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/crates/http-api-bookmark/Cargo.toml
+++ b/crates/http-api-bookmark/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-api-bookmark"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/crates/http-api-core/Cargo.toml
+++ b/crates/http-api-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-api-core"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/crates/http-api-icon/Cargo.toml
+++ b/crates/http-api-icon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-api-icon"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/crates/http-api-image/Cargo.toml
+++ b/crates/http-api-image/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-api-image"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/crates/http-api-to-do/Cargo.toml
+++ b/crates/http-api-to-do/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-api-to-do"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/crates/http-api-trivia/Cargo.toml
+++ b/crates/http-api-trivia/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-api-trivia"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/crates/http-api-typing/Cargo.toml
+++ b/crates/http-api-typing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-api-typing"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/crates/http-api/Cargo.toml
+++ b/crates/http-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-api"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 # Starting in Rust 1.62 you can use `cargo add` to add dependencies 
 # to your project.

--- a/crates/logs-reporter/Cargo.toml
+++ b/crates/logs-reporter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "logs-reporter"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 aws-config.workspace = true

--- a/crates/logs-reporter/src/main.rs
+++ b/crates/logs-reporter/src/main.rs
@@ -1,4 +1,4 @@
-use lambda_runtime::{run, service_fn, tracing, Error};
+use lambda_runtime::{Error, run, service_fn, tracing};
 
 mod event_handler;
 use event_handler::function_handler;

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,3 +55,15 @@ fmt:
     - name: rust
       glob: "*.rs"
       run: "rustfmt --edition 2024 {files}"
+
+    - name: python
+      glob: "*.py"
+      run: "uv run ruff format {files}"
+
+    - name: prettier
+      glob: "*.{ts,tsx,css}"
+      run: "pnpm exec prettier --write {files}"
+
+    - name: terraform
+      glob: "*.tf"
+      run: "terraform fmt {files}"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,8 @@
 # Git hooks managed by lefthook (https://lefthook.dev).
 #
 # Installed automatically on `pnpm install` via the root `prepare` script
-# (`lefthook install`). Run manually with `pnpm exec lefthook run pre-commit`.
+# (`lefthook install`). Run manually with `pnpm exec lefthook run pre-commit`;
+# format the whole repo on demand with `pnpm exec lefthook run fmt`.
 #
 # pre-commit auto-formats the staged files and re-stages the fixes
 # (`stage_fixed`). The heavier gates — clippy `-D warnings`, `cargo test`,
@@ -14,9 +15,8 @@ pre-commit:
     - merge
     - rebase
   jobs:
-    # Rust: format the whole workspace so each crate's edition (rust-toolchain
-    # is pinned; crates mix 2021/2024) is respected, then re-stage the staged
-    # *.rs files that changed.
+    # Rust: format the whole workspace (cargo fmt respects each crate's edition
+    # from Cargo.toml), then re-stage the staged *.rs files that changed.
     - name: rustfmt
       glob: "**/*.rs"
       run: cargo fmt --all
@@ -37,13 +37,21 @@ pre-commit:
     # `exclude` mirrors the `ignores:` in that config, which only applies to
     # its own globbing — not to files passed explicitly on the command line.
     - name: markdownlint
-      glob:
+      glob: &md_glob
         - "*.md"
         - "**/*.md"
-      exclude:
+      exclude: &md_exclude
         - "CLAUDE.md"
         - ".claude/**"
         - ".agents/**"
         - "notes/**"
       run: pnpm exec markdownlint-cli2 --fix {staged_files}
       stage_fixed: true
+
+# lefthook run fmt --file <path>
+fmt:
+  parallel: true
+  jobs:
+    - name: rust
+      glob: "*.rs"
+      run: "rustfmt --edition 2024 {files}"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,6 +8,10 @@
 # (`stage_fixed`). The heavier gates — clippy `-D warnings`, `cargo test`,
 # `tsc` typecheck, eslint — intentionally stay in CI, not here.
 
+# Print nothing on success; on failure print only the failing command's output.
+# Keeps runs quiet and gives the Claude Code `check` hook a minimal report.
+output: false
+
 pre-commit:
   parallel: true
   # Skip while resolving merge conflicts or rebasing.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,49 @@
+# Git hooks managed by lefthook (https://lefthook.dev).
+#
+# Installed automatically on `pnpm install` via the root `prepare` script
+# (`lefthook install`). Run manually with `pnpm exec lefthook run pre-commit`.
+#
+# pre-commit auto-formats the staged files and re-stages the fixes
+# (`stage_fixed`). The heavier gates — clippy `-D warnings`, `cargo test`,
+# `tsc` typecheck, eslint — intentionally stay in CI, not here.
+
+pre-commit:
+  parallel: true
+  # Skip while resolving merge conflicts or rebasing.
+  skip:
+    - merge
+    - rebase
+  jobs:
+    # Rust: format the whole workspace so each crate's edition (rust-toolchain
+    # is pinned; crates mix 2021/2024) is respected, then re-stage the staged
+    # *.rs files that changed.
+    - name: rustfmt
+      glob: "**/*.rs"
+      run: cargo fmt --all
+      stage_fixed: true
+
+    # Web (packages/web-qwik): Prettier on staged TS/TSX/CSS under src/.
+    # `root` sets the CWD (so .prettierignore applies) and makes
+    # {staged_files} relative to it; globs stay repo-root-relative.
+    - name: prettier
+      root: "packages/web-qwik/"
+      glob:
+        - "packages/web-qwik/src/*.{ts,tsx,css}"
+        - "packages/web-qwik/src/**/*.{ts,tsx,css}"
+      run: pnpm exec prettier --write {staged_files}
+      stage_fixed: true
+
+    # Markdown: markdownlint-cli2 --fix, honoring .markdownlint-cli2.yaml.
+    # `exclude` mirrors the `ignores:` in that config, which only applies to
+    # its own globbing — not to files passed explicitly on the command line.
+    - name: markdownlint
+      glob:
+        - "*.md"
+        - "**/*.md"
+      exclude:
+        - "CLAUDE.md"
+        - ".claude/**"
+        - ".agents/**"
+        - "notes/**"
+      run: pnpm exec markdownlint-cli2 --fix {staged_files}
+      stage_fixed: true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -67,3 +67,27 @@ fmt:
     - name: terraform
       glob: "*.tf"
       run: "terraform fmt {files}"
+
+# lefthook run lint --file <path>
+check:
+  parallel: true
+  jobs:
+    - name: rust
+      glob: "*.rs"
+      run: "cargo clippy --all-targets --all-features -- -D warnings"
+
+    - name: python-lint
+      glob: "*.py"
+      run: "uv run ruff check {files}"
+
+    - name: python-typecheck
+      glob: "*.py"
+      run: "uv run pyright {files}"
+
+    - name: prettier
+      glob: "*.{ts,tsx,css}"
+      run: "pnpm exec prettier --check {files}"
+
+    - name: terraform
+      glob: "*.tf"
+      run: "terraform fmt -check {files}"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "scripts": {
-    "lint": "markdownlint-cli2"
+    "lint": "markdownlint-cli2",
+    "prepare": "lefthook install"
   },
   "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee",
   "devDependencies": {
+    "lefthook": "^2.1.9",
     "markdownlint-cli2": "^0.22.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      lefthook:
+        specifier: ^2.1.9
+        version: 2.1.9
       markdownlint-cli2:
         specifier: ^0.22.1
         version: 0.22.1
@@ -3231,6 +3234,60 @@ packages:
 
   launch-editor@2.12.0:
     resolution: {integrity: sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==}
+
+  lefthook-darwin-arm64@2.1.9:
+    resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.9:
+    resolution: {integrity: sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.9:
+    resolution: {integrity: sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.9:
+    resolution: {integrity: sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.9:
+    resolution: {integrity: sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.9:
+    resolution: {integrity: sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.9:
+    resolution: {integrity: sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.9:
+    resolution: {integrity: sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.9:
+    resolution: {integrity: sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.9:
+    resolution: {integrity: sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.9:
+    resolution: {integrity: sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==}
+    hasBin: true
 
   less@4.6.4:
     resolution: {integrity: sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==}
@@ -8124,6 +8181,49 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.3
+
+  lefthook-darwin-arm64@2.1.9:
+    optional: true
+
+  lefthook-darwin-x64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.9:
+    optional: true
+
+  lefthook-linux-arm64@2.1.9:
+    optional: true
+
+  lefthook-linux-x64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.9:
+    optional: true
+
+  lefthook-windows-arm64@2.1.9:
+    optional: true
+
+  lefthook-windows-x64@2.1.9:
+    optional: true
+
+  lefthook@2.1.9:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.9
+      lefthook-darwin-x64: 2.1.9
+      lefthook-freebsd-arm64: 2.1.9
+      lefthook-freebsd-x64: 2.1.9
+      lefthook-linux-arm64: 2.1.9
+      lefthook-linux-x64: 2.1.9
+      lefthook-openbsd-arm64: 2.1.9
+      lefthook-openbsd-x64: 2.1.9
+      lefthook-windows-arm64: 2.1.9
+      lefthook-windows-x64: 2.1.9
 
   less@4.6.4:
     dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,8 @@ dependencies = [
 
 [tool.uv.workspace]
 members = ["python/*"]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.15.19",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,6 @@ members = ["python/*"]
 
 [dependency-groups]
 dev = [
+    "pyright>=1.1.410",
     "ruff>=0.15.19",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1036,8 +1036,16 @@ dependencies = [
     { name = "pyright" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "pyright", specifier = ">=1.1.410" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.15.19" }]
 
 [[package]]
 name = "jinja2"
@@ -2293,6 +2301,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
     { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
     { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/e6/15800dfde183a1a106594016c912b4c12d050a301989d1aca6cb63759fe8/ruff-0.15.19.tar.gz", hash = "sha256:edc27f7172a93b32b102687009d6a588508815072141543ae603a8b9b0823063", size = 4772071, upload-time = "2026-06-24T01:10:46.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/4c/9ded7626c39a0440c575bf69e2bf500d443388272c842662c59852ee7fcd/ruff-0.15.19-py3-none-linux_armv6l.whl", hash = "sha256:922d1eb283161564759bd49f507e91dc6112c15da8bd5b84ed714e086243cf86", size = 10950859, upload-time = "2026-06-24T01:10:38.491Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ef/c211505ece1d00ef493d58e54e3b6383c946a21e9874774eb531f2512cf3/ruff-0.15.19-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4d190d8f62a0b94aba8f721116538a9ee29b1e74d26650846ba9b99f0ae21c40", size = 11294529, upload-time = "2026-06-24T01:10:36.481Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/78d462e7d39968e58094dc57be7d09ffb14ce37da5b68ed70338a35a1f21/ruff-0.15.19-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a2c86ba6870dd415a9d9eb8be94d7924ebec6a26ffc7958ec7ca29d4bff967d", size = 10641416, upload-time = "2026-06-24T01:10:48.923Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c4/5cb66cfd1f865d5cca908b86c93ac785e7f572193d3c7426079ca6643e24/ruff-0.15.19-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b432bc087264aea70fd25ac198918b70bd9e2aa0db4297b0bb91bbfbbc63ce", size = 11015582, upload-time = "2026-06-24T01:10:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9f/8ecfaec10cf5eecd28fbc00ff4fb867db90a1be54bf3d39ebf93f893cd52/ruff-0.15.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8530a09d03b3a8c994f8b559a7dcdabc690bcd3f78ef276c38c83166798ebf56", size = 10744059, upload-time = "2026-06-24T01:10:32.48Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6b/983249d04562bc2d590edd75f32455cdb473affb3ba4bc8d883e939c697d/ruff-0.15.19-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87bf21fb3875fe69f0eacc825411657e2e85589cce633c35c0adf1113649c62b", size = 11568461, upload-time = "2026-06-24T01:10:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/39/bc7794f127b18f492a3b4ee82bba5a900c985ff13b72b46f46e3c171ba34/ruff-0.15.19-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b229cb3ef56ecc2c1c8ebeca64b7a7740ccaef40a9eb097e78dde5a8560b83", size = 12429690, upload-time = "2026-06-24T01:10:40.638Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/3b/0de6859e698ed11c8a49e765196c8d333599b6a546c0715df39b6ba1aa2e/ruff-0.15.19-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6c754515be7b76afe6e7e62df7776709571bcfc1631183828afcf3bafa869e3", size = 11693067, upload-time = "2026-06-24T01:10:25.681Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3d/0b1f30f84bee9ae6ae8d349c2ba8b6f4b040966744efdd3acc804ae7c024/ruff-0.15.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a498f82e0f4d8904c4e0aea5139cdfac1f39d19a3c51d491292f63a36e83b2e", size = 11616911, upload-time = "2026-06-24T01:10:44.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/eb/c90bd3dfc12eed9032c2c1bfe05105b93a1b2c8bce555db6308315b853ce/ruff-0.15.19-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:d48caa34488fb521fd0ef4aea2b0e8fe758298df044138f0d67b687a6a0d07ed", size = 11649343, upload-time = "2026-06-24T01:10:23.472Z" },
+    { url = "https://files.pythonhosted.org/packages/82/91/01caa13602a2f12fae5edbe8caf78b3c1e6db1293132aee6959eecce095c/ruff-0.15.19-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4171b6613effa9363cd46dd4f75bd1827b6d1b946b5e278ed0c600d305379445", size = 10977610, upload-time = "2026-06-24T01:10:50.892Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/acb817922feab9ecbb3201377d4dbe7a25f1395e46545820061973f03468/ruff-0.15.19-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:27c15b2a241dd4d995557949a094fe78b8ad99122a38ccae1595849bcc947b3f", size = 10744900, upload-time = "2026-06-24T01:10:42.726Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bc/5c8ca46b8a7a3f2b16cfbec88721d772b1c93912904e8f8c2e49470fea63/ruff-0.15.19-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ed03b7862d68f0a8771d50ee129980cbf1b113f96e250b73954bc292f689e0bb", size = 11293560, upload-time = "2026-06-24T01:10:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e0/4a888cbe4d5523b3f77a2b1fa043f46cfeba1b32eac35dcfadee0578fa8a/ruff-0.15.19-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:08143f0685ae278b30727ea72e90c61e5bd9c31b91aac4f5bb989538f73d24b8", size = 11696533, upload-time = "2026-06-24T01:10:53.046Z" },
+    { url = "https://files.pythonhosted.org/packages/98/43/c34b2fcd79262a85161764a97aaca89c3e4f574340ab61430cefa2bdd2c1/ruff-0.15.19-py3-none-win32.whl", hash = "sha256:8f47f0f92952af2557212bb10cf3e695cd4cf28b2c6e42cdb18ec6c9ebfa19da", size = 10986299, upload-time = "2026-06-24T01:10:55.185Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e8/15fd23e02b2442b56b2026b455977bc3057aa34b26e6323d1e99e8531a9f/ruff-0.15.19-py3-none-win_amd64.whl", hash = "sha256:efeca47ee3f9d4a7162655a3b8e6ee4a878646044233978d4d2c1ff8cdd914f0", size = 12123473, upload-time = "2026-06-24T01:10:27.74Z" },
+    { url = "https://files.pythonhosted.org/packages/30/66/9a73695e31eaee04f35d8475998bf8ab354465f9c638936d76111603dcc5/ruff-0.15.19-py3-none-win_arm64.whl", hash = "sha256:6c6b607466e47349332eb1d9be52fb1467423fc07c217341af41cd0f3f0573be", size = 11376779, upload-time = "2026-06-24T01:10:34.465Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1038,6 +1038,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyright" },
     { name = "ruff" },
 ]
 
@@ -1045,7 +1046,10 @@ dev = [
 requires-dist = [{ name = "pyright", specifier = ">=1.1.410" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.19" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.410" },
+    { name = "ruff", specifier = ">=0.15.19" },
+]
 
 [[package]]
 name = "jinja2"


### PR DESCRIPTION
## Summary

Sets up repo-wide formatting/linting via [lefthook](https://lefthook.dev), unifies the Rust workspace on the 2024 edition, and wires both into Claude Code via project hooks.

### lefthook
- **`pre-commit`** — auto-formats staged files and re-stages the fixes (`cargo fmt`, Prettier for `web-qwik/src`, markdownlint). Heavier gates (clippy, tests, typecheck) stay in CI.
- **`fmt`** command — `rustfmt`/`ruff format`/`prettier`/`terraform fmt`, scoped per file via `--file`.
- **`check`** command — `clippy -D warnings`, `ruff check`, `pyright`, `prettier --check`, `terraform fmt -check`.
- `output: false` — quiet on success; on failure prints only the failing command's output.

### Rust
- Unified the workspace on the **2024 edition**.

### Claude Code hooks (`.claude/`)
- `settings.json` wires two hooks to lefthook:
  - **`PostToolUse` (Edit|Write)** → `lefthook run fmt --file <path>` — auto-formats the file just edited (repo-scoped, non-blocking).
  - **`Stop`** → runs `lefthook run check` over working-tree changes; on failure it **blocks** and feeds the minimal error back so it gets fixed before stopping. `stop_hook_active` guards against an infinite loop.

## Test plan
- [x] `lefthook run fmt --file <abs path>` scopes to matching jobs only.
- [x] PostToolUse hook reformats a mis-formatted `.tf` edit back to clean.
- [x] Stop hook blocks on a `ruff` F401 violation and relays just the error; allows stop once resolved / when `stop_hook_active`.
- [x] `output: false` verified silent on success, error-only on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)