### PR TITLE
refactor(web-qwik): data-only context stores with action hooks

### DIFF
--- a/packages/web-qwik/src/container/todo-container.tsx
+++ b/packages/web-qwik/src/container/todo-container.tsx
@@ -20,7 +20,7 @@ import {
   ElmMdiIcon,
 } from "@elmethis/qwik";
 import { openApiClient } from "~/openapi/client";
-import { AuthContext } from "~/context/auth-context";
+import { AuthContext, useAuthActions } from "~/context/auth-context";
 
 import { mdiAlert, mdiSortCalendarAscending, mdiSync } from "@mdi/js";
 
@@ -46,6 +46,7 @@ type Severity = ToDo["severity"];
 export const TodoContainer = component$<TodoContainerProps>(
   ({ class: className, style }) => {
     const authStore = useContext(AuthContext);
+    const { refresh } = useAuthActions();
 
     const todoItemContainerRef = useSignal<HTMLElement>();
     const animationController =
@@ -72,7 +73,7 @@ export const TodoContainer = component$<TodoContainerProps>(
     const execute = $(async () => {
       isLoading.value = true;
       try {
-        await authStore.tokens.refresh(authStore);
+        await refresh();
         const accessToken = authStore.tokens.accessToken;
 
         if (accessToken == null) return;
@@ -114,7 +115,7 @@ export const TodoContainer = component$<TodoContainerProps>(
       updateStateStore.updatingIds.push(id);
 
       try {
-        await authStore.tokens.refresh(authStore);
+        await refresh();
         const accessToken = authStore.tokens.accessToken;
 
         if (accessToken == null) return;
@@ -210,7 +211,7 @@ export const TodoContainer = component$<TodoContainerProps>(
         severity: Severity;
         deadline?: string;
       }) => {
-        await authStore.tokens.refresh(authStore);
+        await refresh();
         const accessToken = authStore.tokens.accessToken;
 
         if (accessToken == null) throw new Error("Access token is null");

--- a/packages/web-qwik/src/context/anki-context.tsx
+++ b/packages/web-qwik/src/context/anki-context.tsx
@@ -9,7 +9,7 @@ import {
 } from "@qwik.dev/core";
 import { openApiClient } from "~/openapi/client";
 import { paths } from "~/openapi/schema";
-import { AuthContext } from "./auth-context";
+import { AuthContext, AuthState, useAuthActions } from "./auth-context";
 
 type AnkiMeta =
   paths["/api/v1/anki/{page_id}"]["get"]["responses"]["200"]["content"]["application/json"];
@@ -20,7 +20,10 @@ type AnkiBlock = {
   front: unknown;
 };
 
-export interface AnkiStore {
+/**
+ * Serializable anki state. Behavior lives in `useAnkiActions()`.
+ */
+export interface AnkiState {
   error: string | null;
 
   ankiList: {
@@ -33,301 +36,295 @@ export interface AnkiStore {
     loading: boolean;
   };
 
-  updateAnkiByPerformanceRating?: QRL<
-    (
-      ankiStore: AnkiStore,
-      pageId: string,
-      performanceRating: number,
-    ) => Promise<void>
-  >;
-
-  fetchAnkiBlock: QRL<
-    (store: AnkiStore, pageId?: string, signal?: AbortSignal) => Promise<void>
-  >;
-
-  create: {
-    execute: QRL<(store: AnkiStore) => Promise<void>>;
-    loading: boolean;
-  };
-
-  review: {
-    execute: QRL<(store: AnkiStore) => Promise<void>>;
-    loading: boolean;
-  };
+  create: { loading: boolean };
+  review: { loading: boolean };
 }
 
-export const AnkiContext = createContextId<AnkiStore>("anki");
+export const AnkiContext = createContextId<AnkiState>("anki");
+
+type Refresh = QRL<() => Promise<void>>;
+
+// Shared fetch logic with explicit dependencies, so both the provider's
+// bootstrap tasks and `useAnkiActions()` drive it without either having to
+// consume a context the other provides.
+const fetchAnkiList = async (
+  anki: AnkiState,
+  auth: AuthState,
+  refresh: Refresh,
+  signal?: AbortSignal,
+) => {
+  anki.ankiList.loading = true;
+
+  try {
+    await refresh();
+
+    const { data: ankiListData } = await openApiClient.GET("/api/v1/anki", {
+      params: {
+        header: { Authorization: `Bearer ${auth.tokens.accessToken}` },
+      },
+      signal,
+    });
+
+    if (ankiListData)
+      anki.ankiList.data = ankiListData.map((item) => ({
+        metadata: item,
+        block: null,
+        loading: false,
+      }));
+
+    if (ankiListData && ankiListData.length > 0) anki.ankiList.currentIndex = 0;
+  } catch (error) {
+    if (!(error instanceof Error && error.name === "AbortError")) {
+      anki.error =
+        "Failed to fetch Anki list. " +
+        (error instanceof Error ? error.message : String(error));
+    }
+  } finally {
+    if (!signal?.aborted) anki.ankiList.loading = false;
+  }
+};
+
+const fetchAnkiBlock = async (
+  anki: AnkiState,
+  auth: AuthState,
+  refresh: Refresh,
+  pageId?: string,
+  signal?: AbortSignal,
+) => {
+  const ankiRef = anki.ankiList.data.find(
+    (item) => item.metadata.page_id === pageId,
+  );
+
+  try {
+    if (!pageId) throw new Error("Page ID is required to fetch Anki block.");
+    if (!ankiRef)
+      throw new Error(`Anki with page_id ${pageId} not found in the list.`);
+
+    // Prevent multiple fetches for the same block
+    if (ankiRef.loading) return;
+
+    ankiRef.loading = true;
+
+    await refresh();
+
+    const { data: ankiBlockData } = await openApiClient.GET(
+      "/api/v1/anki/block/{page_id}",
+      {
+        params: {
+          header: { Authorization: `Bearer ${auth.tokens.accessToken}` },
+          path: { page_id: pageId },
+        },
+        signal,
+      },
+    );
+
+    if (ankiBlockData) ankiRef.block = ankiBlockData as AnkiBlock;
+  } catch (error) {
+    if (!(error instanceof Error && error.name === "AbortError")) {
+      anki.error =
+        "Failed to fetch Anki block. " +
+        (error instanceof Error ? error.message : String(error));
+    }
+  } finally {
+    if (ankiRef && !signal?.aborted) ankiRef.loading = false;
+  }
+};
+
+export const useAnkiActions = () => {
+  const auth = useContext(AuthContext);
+  const anki = useContext(AnkiContext);
+  const { refresh } = useAuthActions();
+
+  const fetchList = $((signal?: AbortSignal) =>
+    fetchAnkiList(anki, auth, refresh, signal),
+  );
+
+  const fetchBlock = $((pageId?: string, signal?: AbortSignal) =>
+    fetchAnkiBlock(anki, auth, refresh, pageId, signal),
+  );
+
+  const updateByRating = $(
+    async (pageId: string, performanceRating: number) => {
+      const ankiRef = anki.ankiList.data.find(
+        (item) => item.metadata.page_id === pageId,
+      );
+
+      try {
+        if (!ankiRef)
+          throw new Error(`Anki with page_id ${pageId} not found in the list.`);
+
+        await refresh();
+
+        const maxInterval = 365 / 4;
+        const minInterval = 0.5;
+
+        let newEaseFactor: number;
+        let newRepetitionCount: number;
+
+        if (performanceRating < 3) {
+          newEaseFactor = Math.max(1.3, ankiRef.metadata.ease_factor * 0.85);
+          newRepetitionCount = 0;
+        } else {
+          newEaseFactor =
+            ankiRef.metadata.ease_factor +
+            0.1 -
+            (5 - performanceRating) * (0.08 + (5 - performanceRating) * 0.02);
+          newRepetitionCount = ankiRef.metadata.repetition_count + 1;
+        }
+
+        let newInterval;
+        if (performanceRating === 0) {
+          newInterval = minInterval;
+        } else if (performanceRating === 1) {
+          newInterval = minInterval;
+        } else if (performanceRating === 2) {
+          newInterval = Math.max(minInterval, newRepetitionCount);
+        } else {
+          let multiplier = 1;
+          if (performanceRating === 3) {
+            multiplier = 1;
+          } else if (performanceRating === 4) {
+            multiplier = 1.5;
+          } else if (performanceRating === 5) {
+            multiplier = 2;
+          }
+          newInterval = Math.min(
+            maxInterval,
+            Math.pow(newEaseFactor, newRepetitionCount) * multiplier,
+          );
+        }
+
+        const newNextReviewAt = new Date(
+          Date.now() + newInterval * 24 * 60 * 60 * 1000,
+        ).toISOString();
+
+        ankiRef.metadata.ease_factor = newEaseFactor;
+        ankiRef.metadata.repetition_count = newRepetitionCount;
+        ankiRef.metadata.next_review_at = newNextReviewAt;
+
+        const payload = {
+          ease_factor: newEaseFactor,
+          repetition_count: newRepetitionCount,
+          next_review_at: newNextReviewAt,
+        };
+
+        // Fire-and-forget: the UI advances immediately; the write lands in the
+        // background.
+        void openApiClient.PUT(`/api/v1/anki/{page_id}`, {
+          params: {
+            header: {
+              Authorization: `Bearer ${auth.tokens.accessToken}`,
+            },
+            path: { page_id: ankiRef.metadata.page_id },
+          },
+          body: payload,
+        });
+
+        if (anki.ankiList.currentIndex != null) {
+          anki.ankiList.currentIndex = anki.ankiList.currentIndex + 1;
+        } else {
+          anki.ankiList.currentIndex = 0;
+        }
+      } catch (error) {
+        if (ankiRef)
+          anki.error =
+            "Failed to fetch Anki block. " +
+            (error instanceof Error ? error.message : String(error));
+      }
+    },
+  );
+
+  const create = $(async () => {
+    anki.create.loading = true;
+
+    try {
+      await refresh();
+
+      const { data } = await openApiClient.POST("/api/v1/anki", {
+        params: {
+          header: {
+            Authorization: `Bearer ${auth.tokens.accessToken}`,
+          },
+        },
+        body: {},
+      });
+
+      if (data == null) {
+        throw new Error("No data returned from API");
+      } else {
+        const a = document.createElement("a");
+        a.href = data.url.replace(/https?\/\//, "notionrs://");
+        a.target = "_blank";
+        a.rel = "noopener noreferrer";
+        a.click();
+      }
+    } catch (error) {
+      anki.error =
+        "Failed to create new Anki. " +
+        (error instanceof Error ? error.message : String(error));
+    } finally {
+      anki.create.loading = false;
+    }
+  });
+
+  const review = $(async () => {
+    anki.review.loading = true;
+    try {
+      if (anki.ankiList.currentIndex == null) {
+        throw new Error("No current Anki to review");
+      }
+
+      const currentAnki = anki.ankiList.data[anki.ankiList.currentIndex];
+
+      await refresh();
+
+      const res = await openApiClient.PUT(`/api/v1/anki/{page_id}`, {
+        params: {
+          header: {
+            Authorization: `Bearer ${auth.tokens.accessToken}`,
+          },
+          path: {
+            page_id: currentAnki.metadata.page_id,
+          },
+        },
+        body: {
+          is_review_required: !currentAnki.metadata.is_review_required,
+        },
+      });
+
+      if (!res.data) {
+        throw new Error("No data returned from API");
+      }
+
+      currentAnki.metadata.is_review_required = res.data.is_review_required;
+    } catch (error) {
+      anki.error =
+        "Failed to review Anki. " +
+        (error instanceof Error ? error.message : String(error));
+    } finally {
+      anki.review.loading = false;
+    }
+  });
+
+  return { fetchList, fetchBlock, updateByRating, create, review };
+};
 
 export const useAnkiContextProvider = () => {
-  const authStore = useContext(AuthContext);
+  const auth = useContext(AuthContext);
+  const { refresh } = useAuthActions();
 
-  const ankiStore = useStore<AnkiStore>({
+  const ankiStore = useStore<AnkiState>({
     error: null,
-
     ankiList: {
       data: [],
       currentIndex: null,
       loading: false,
     },
-
-    updateAnkiByPerformanceRating: $(
-      async (store: AnkiStore, pageId: string, performanceRating: number) => {
-        const ankiRef = store.ankiList.data.find(
-          (anki) => anki.metadata.page_id === pageId,
-        );
-
-        try {
-          if (!ankiRef)
-            throw new Error(
-              `Anki with page_id ${pageId} not found in the list.`,
-            );
-
-          await authStore.tokens.refresh(authStore);
-
-          const maxInterval = 365 / 4;
-          const minInterval = 0.5;
-
-          let newEaseFactor: number;
-          let newRepetitionCount: number;
-
-          if (performanceRating < 3) {
-            newEaseFactor = Math.max(1.3, ankiRef.metadata.ease_factor * 0.85);
-            newRepetitionCount = 0;
-          } else {
-            newEaseFactor =
-              ankiRef.metadata.ease_factor +
-              0.1 -
-              (5 - performanceRating) * (0.08 + (5 - performanceRating) * 0.02);
-            newRepetitionCount = ankiRef.metadata.repetition_count + 1;
-          }
-
-          let newInterval;
-          if (performanceRating === 0) {
-            newInterval = minInterval;
-          } else if (performanceRating === 1) {
-            newInterval = minInterval;
-          } else if (performanceRating === 2) {
-            newInterval = Math.max(minInterval, newRepetitionCount);
-          } else {
-            let multiplier = 1;
-            if (performanceRating === 3) {
-              multiplier = 1;
-            } else if (performanceRating === 4) {
-              multiplier = 1.5;
-            } else if (performanceRating === 5) {
-              multiplier = 2;
-            }
-            newInterval = Math.min(
-              maxInterval,
-              Math.pow(newEaseFactor, newRepetitionCount) * multiplier,
-            );
-          }
-
-          const newNextReviewAt = new Date(
-            Date.now() + newInterval * 24 * 60 * 60 * 1000,
-          ).toISOString();
-
-          ankiRef.metadata.ease_factor = newEaseFactor;
-          ankiRef.metadata.repetition_count = newRepetitionCount;
-          ankiRef.metadata.next_review_at = newNextReviewAt;
-
-          const payload = {
-            ease_factor: newEaseFactor,
-            repetition_count: newRepetitionCount,
-            next_review_at: newNextReviewAt,
-          };
-
-          (async () => {
-            await openApiClient.PUT(`/api/v1/anki/{page_id}`, {
-              params: {
-                header: {
-                  Authorization: `Bearer ${authStore.tokens.accessToken}`,
-                },
-                path: { page_id: ankiRef!.metadata.page_id },
-              },
-              body: payload,
-            });
-          })();
-
-          if (store.ankiList.currentIndex != null) {
-            store.ankiList.currentIndex = store.ankiList.currentIndex + 1;
-          } else {
-            store.ankiList.currentIndex = 0;
-          }
-        } catch (error) {
-          if (ankiRef)
-            store.error =
-              "Failed to fetch Anki block. " +
-              (error instanceof Error ? error.message : String(error));
-        }
-      },
-    ),
-
-    fetchAnkiBlock: $(
-      async (store: AnkiStore, pageId?: string, signal?: AbortSignal) => {
-        const ankiRef = store.ankiList.data.find(
-          (anki) => anki.metadata.page_id === pageId,
-        );
-
-        try {
-          if (!pageId)
-            throw new Error("Page ID is required to fetch Anki block.");
-          if (!ankiRef)
-            throw new Error(
-              `Anki with page_id ${pageId} not found in the list.`,
-            );
-
-          // Prevent multiple fetches for the same block
-          if (ankiRef.loading) return;
-
-          ankiRef.loading = true;
-
-          await authStore.tokens.refresh(authStore);
-
-          const { data: ankiBlockData } = await openApiClient.GET(
-            `/api/v1/anki/block/{page_id}`,
-            {
-              params: {
-                header: {
-                  Authorization: `Bearer ${authStore.tokens.accessToken}`,
-                },
-                path: { page_id: pageId },
-              },
-              signal,
-            },
-          );
-
-          if (ankiBlockData) ankiRef.block = ankiBlockData as AnkiBlock;
-        } catch (error) {
-          if (!(error instanceof Error && error.name === "AbortError")) {
-            store.error =
-              "Failed to fetch Anki block. " +
-              (error instanceof Error ? error.message : String(error));
-          }
-        } finally {
-          if (ankiRef && !signal?.aborted) ankiRef.loading = false;
-        }
-      },
-    ),
-
-    create: {
-      execute: $(async (store: AnkiStore) => {
-        store.create.loading = true;
-
-        try {
-          await authStore.tokens.refresh(authStore);
-
-          const { data } = await openApiClient.POST("/api/v1/anki", {
-            params: {
-              header: {
-                Authorization: `Bearer ${authStore.tokens.accessToken}`,
-              },
-            },
-            body: {},
-          });
-
-          if (data == null) {
-            throw new Error("No data returned from API");
-          } else {
-            const a = document.createElement("a");
-            a.href = data.url.replace(/https?\/\//, "notionrs://");
-            a.target = "_blank";
-            a.rel = "noopener noreferrer";
-            a.click();
-          }
-        } catch (error) {
-          store.error =
-            "Failed to create new Anki. " +
-            (error instanceof Error ? error.message : String(error));
-        } finally {
-          store.create.loading = false;
-        }
-      }),
-      loading: false,
-    },
-
-    review: {
-      execute: $(async (store: AnkiStore) => {
-        store.review.loading = true;
-        try {
-          if (store.ankiList.currentIndex == null) {
-            throw new Error("No current Anki to review");
-          }
-
-          const currentAnki = store.ankiList.data[store.ankiList.currentIndex];
-
-          await authStore.tokens.refresh(authStore);
-
-          const res = await openApiClient.PUT(`/api/v1/anki/{page_id}`, {
-            params: {
-              header: {
-                Authorization: `Bearer ${authStore.tokens.accessToken}`,
-              },
-              path: {
-                page_id: currentAnki.metadata.page_id,
-              },
-            },
-            body: {
-              is_review_required: !currentAnki.metadata.is_review_required,
-            },
-          });
-
-          if (!res.data) {
-            throw new Error("No data returned from API");
-          }
-
-          currentAnki.metadata.is_review_required = res.data.is_review_required;
-        } catch (error) {
-          store.error =
-            "Failed to review Anki. " +
-            (error instanceof Error ? error.message : String(error));
-        } finally {
-          store.review.loading = false;
-        }
-      }),
-      loading: false,
-    },
+    create: { loading: false },
+    review: { loading: false },
   });
 
   useContextProvider(AnkiContext, ankiStore);
-
-  const fetchAnkiList = $(async (controller?: AbortController) => {
-    ankiStore.ankiList.loading = true;
-
-    try {
-      await authStore.tokens.refresh(authStore);
-
-      const { data: ankiListData } = await openApiClient.GET("/api/v1/anki", {
-        params: {
-          header: {
-            Authorization: `Bearer ${authStore.tokens.accessToken}`,
-          },
-        },
-        signal: controller?.signal,
-      });
-
-      if (ankiListData)
-        ankiStore.ankiList.data = ankiListData.map((anki) => ({
-          metadata: anki,
-          block: null,
-          loading: false,
-          error: null,
-        }));
-
-      if (ankiListData && ankiListData.length > 0)
-        ankiStore.ankiList.currentIndex = 0;
-    } catch (error) {
-      if (!(error instanceof Error && error.name === "AbortError")) {
-        ankiStore.error =
-          "Failed to fetch Anki list. " +
-          (error instanceof Error ? error.message : String(error));
-      }
-    } finally {
-      if (!controller?.signal.aborted) {
-        ankiStore.ankiList.loading = false;
-      }
-    }
-  });
 
   // `document-ready`: called from a layout that returns a Fragment, so the
   // default intersection-observer has no host element to attach to.
@@ -337,7 +334,7 @@ export const useAnkiContextProvider = () => {
       const controller = new AbortController();
       cleanup(() => controller.abort());
 
-      fetchAnkiList(controller);
+      fetchAnkiList(ankiStore, auth, refresh, controller.signal);
     },
     { strategy: "document-ready" },
   );
@@ -352,29 +349,19 @@ export const useAnkiContextProvider = () => {
 
       if (currentIndex === null) return;
 
-      const currentAnkiRef = ankiStore.ankiList.data[currentIndex];
-      if (currentAnkiRef)
-        ankiStore.fetchAnkiBlock(
-          ankiStore,
-          currentAnkiRef.metadata.page_id,
-          controller.signal,
-        );
-
-      const nextAnkiRef = ankiStore.ankiList.data[currentIndex + 1];
-      if (nextAnkiRef)
-        ankiStore.fetchAnkiBlock(
-          ankiStore,
-          nextAnkiRef.metadata.page_id,
-          controller.signal,
-        );
-
-      const nextNextAnkiRef = ankiStore.ankiList.data[currentIndex + 2];
-      if (nextNextAnkiRef)
-        ankiStore.fetchAnkiBlock(
-          ankiStore,
-          nextNextAnkiRef.metadata.page_id,
-          controller.signal,
-        );
+      // Prefetch the current block plus the next two, so navigating forward
+      // lands on already-loaded content.
+      [currentIndex, currentIndex + 1, currentIndex + 2].forEach((index) => {
+        const ref = ankiStore.ankiList.data[index];
+        if (ref)
+          fetchAnkiBlock(
+            ankiStore,
+            auth,
+            refresh,
+            ref.metadata.page_id,
+            controller.signal,
+          );
+      });
     },
     { strategy: "document-ready" },
   );

--- a/packages/web-qwik/src/context/auth-context.tsx
+++ b/packages/web-qwik/src/context/auth-context.tsx
@@ -1,17 +1,21 @@
 import {
   $,
   createContextId,
-  QRL,
+  noSerialize,
+  NoSerialize,
   useContext,
   useContextProvider,
   useStore,
   useVisibleTask$,
 } from "@qwik.dev/core";
-import { signOut } from "aws-amplify/auth";
+import { signOut as cognitoSignOut } from "aws-amplify/auth";
 
 // AWS Amplify
 import { Amplify } from "aws-amplify";
-import { getCurrentUser, signIn } from "aws-amplify/auth/cognito";
+import {
+  getCurrentUser,
+  signIn as cognitoSignIn,
+} from "aws-amplify/auth/cognito";
 import { fetchAuthSession } from "aws-amplify/auth";
 
 const AuthConfigMap: Record<
@@ -40,80 +44,106 @@ const configure = () => {
   });
 };
 
-export interface AuthStore {
+/**
+ * Serializable auth state. Behavior lives in `useAuthActions()`; this store
+ * holds data only so it stays cheap to serialize at the document root.
+ */
+export interface AuthState {
   sessionState: "pending" | "login" | "logout";
   errors: string[];
   signingInProgress: boolean;
 
-  signOut: QRL<(store: AuthStore) => Promise<void>>;
-  signIn: QRL<
-    (store: AuthStore, username: string, password: string) => Promise<void>
-  >;
-
   tokens: {
-    loading: boolean;
-    refresh: QRL<(store: AuthStore) => Promise<void>>;
     accessToken: string | null;
+    // In-flight refresh shared across callers (single-flight). `noSerialize`
+    // because a Promise never crosses the resume boundary.
+    refreshInFlight?: NoSerialize<Promise<void>>;
   };
 }
 
-export const AuthContext = createContextId<AuthStore>("auth");
+export const AuthContext = createContextId<AuthState>("auth");
 
 export const useAuthContextProvider = () => {
-  const authStore = useStore<AuthStore>({
-    sessionState: "pending",
-    errors: [],
-    signingInProgress: false,
-
-    signOut: $(async (store: AuthStore) => {
-      store.sessionState = "pending";
-      await signOut();
-      store.sessionState = "logout";
+  useContextProvider(
+    AuthContext,
+    useStore<AuthState>({
+      sessionState: "pending",
+      errors: [],
+      signingInProgress: false,
+      tokens: {
+        accessToken: null,
+      },
     }),
+  );
+};
 
-    signIn: $(async (store: AuthStore, username: string, password: string) => {
-      store.signingInProgress = true;
+/**
+ * Auth actions. Each reads the provided store from context, so callers never
+ * pass the store in. Safe to call from any `component$` under the provider
+ * (mounted in `root.tsx`).
+ */
+export const useAuthActions = () => {
+  const store = useContext(AuthContext);
+
+  const refresh = $(async () => {
+    // Single-flight: if a refresh is already running, await it instead of
+    // firing a second `fetchAuthSession`. Replaces the former busy-wait on a
+    // `tokens.loading` flag.
+    if (store.tokens.refreshInFlight) {
+      await store.tokens.refreshInFlight;
+      return;
+    }
+
+    const run = async () => {
+      store.errors = [];
+      configure();
 
       try {
-        configure();
-
-        const result = await signIn({
-          username: username,
-          password: password,
-        });
-
-        if (result.isSignedIn) {
-          store.tokens.refresh(store);
-        }
-      } catch {
+        const session = await fetchAuthSession({ forceRefresh: false });
+        const accessToken = session.tokens?.accessToken.toString();
+        store.tokens.accessToken = accessToken ?? null;
+        store.sessionState = store.tokens.accessToken ? "login" : "logout";
+      } catch (e: unknown) {
+        store.tokens.accessToken = null;
         store.sessionState = "logout";
-      } finally {
-        store.signingInProgress = false;
+        store.errors.push(e instanceof Error ? e.message : String(e));
       }
-    }),
+    };
 
-    tokens: {
-      loading: false,
-      accessToken: null,
-      refresh: $(async (store: AuthStore) => {
-        store.errors = [];
-        configure();
-
-        try {
-          const session = await fetchAuthSession({ forceRefresh: false });
-          const accessToken = session.tokens?.accessToken.toString();
-          store.tokens.accessToken = accessToken ?? null;
-          store.sessionState = store.tokens.accessToken ? "login" : "logout";
-        } catch (e: unknown) {
-          store.tokens.accessToken = null;
-          store.sessionState = "logout";
-          store.errors.push(e instanceof Error ? e.message : String(e));
-        }
-      }),
-    },
+    const inflight = run();
+    store.tokens.refreshInFlight = noSerialize(inflight);
+    try {
+      await inflight;
+    } finally {
+      store.tokens.refreshInFlight = undefined;
+    }
   });
 
-  useContextProvider(AuthContext, authStore);
+  const signIn = $(async (username: string, password: string) => {
+    store.signingInProgress = true;
+
+    try {
+      configure();
+
+      const result = await cognitoSignIn({ username, password });
+
+      if (result.isSignedIn) {
+        await refresh();
+      }
+    } catch {
+      store.sessionState = "logout";
+    } finally {
+      store.signingInProgress = false;
+    }
+  });
+
+  const signOut = $(async () => {
+    store.sessionState = "pending";
+    await cognitoSignOut();
+    store.sessionState = "logout";
+  });
+
+  return { refresh, signIn, signOut };
 };
 
 /**
@@ -123,41 +153,23 @@ export const useAuthContextProvider = () => {
  * hooks never run. Pair with `useAuthContextProvider()` in `root.tsx`.
  */
 export const useAuthEffect = () => {
-  const authStore = useContext(AuthContext);
+  const store = useContext(AuthContext);
+  const { refresh } = useAuthActions();
 
   // eslint-disable-next-line qwik/no-use-visible-task
   useVisibleTask$(
     async () => {
       configure();
 
-      let attempts = 0;
-
       try {
-        while (authStore.tokens.loading) {
-          await new Promise((resolve) => setTimeout(resolve, 200));
-          attempts++;
-
-          if (attempts > 25)
-            throw new Error(
-              "Failed to fetch auth session after multiple attempts.",
-            );
-        }
-
-        authStore.tokens.loading = true;
-        await authStore.tokens.refresh(authStore);
+        await refresh();
         const { username, userId } = await getCurrentUser();
-        if (username && userId) {
-          authStore.sessionState = "login";
-        } else {
-          authStore.sessionState = "logout";
-        }
+        store.sessionState = username && userId ? "login" : "logout";
       } catch {
         console.error(
           "Failed to fetch auth session. User might not be authenticated.",
         );
-        authStore.sessionState = "logout";
-      } finally {
-        authStore.tokens.loading = false;
+        store.sessionState = "logout";
       }
     },
     { strategy: "document-ready" },

--- a/packages/web-qwik/src/routes/anki/index.tsx
+++ b/packages/web-qwik/src/routes/anki/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@qwik.dev/core";
 
 import styles from "./anki.module.css";
-import { AnkiContext } from "~/context/anki-context";
+import { AnkiContext, useAnkiActions } from "~/context/anki-context";
 import {
   blockCatalog,
   ElmA2ui,
@@ -43,6 +43,7 @@ const KEYMAP = { q: 0, w: 1, e: 2, a: 3, s: 4, d: 5 };
 
 export default component$<IndexProps>(({ class: className, style }) => {
   const ankiStore = useContext(AnkiContext);
+  const { updateByRating, create, review, fetchBlock } = useAnkiActions();
 
   const currentAnki = useComputed$(() =>
     ankiStore.ankiList.currentIndex != null
@@ -53,14 +54,9 @@ export default component$<IndexProps>(({ class: className, style }) => {
   const isShowingAnswer = useSignal(false);
 
   const handleUpdate = $((pageId?: string, performanceRating?: number) => {
-    if (!ankiStore.updateAnkiByPerformanceRating) return;
     if (!pageId || performanceRating == null) return;
 
-    ankiStore.updateAnkiByPerformanceRating(
-      ankiStore,
-      pageId,
-      performanceRating,
-    );
+    updateByRating(pageId, performanceRating);
 
     if (currentAnki.value?.metadata.page_id === pageId) {
       isShowingAnswer.value = false;
@@ -126,7 +122,7 @@ export default component$<IndexProps>(({ class: className, style }) => {
         <ElmButton
           block
           isLoading={ankiStore.create.loading}
-          onClick$={() => ankiStore.create.execute(ankiStore)}
+          onClick$={() => create()}
         >
           <ElmMdiIcon d={mdiCreation} />
           <span>New</span>
@@ -134,7 +130,7 @@ export default component$<IndexProps>(({ class: className, style }) => {
         <ElmButton
           block
           isLoading={currentAnki.value == null || ankiStore.review.loading}
-          onClick$={() => ankiStore.review.execute(ankiStore)}
+          onClick$={() => review()}
         >
           <ElmMdiIcon
             d={
@@ -148,12 +144,7 @@ export default component$<IndexProps>(({ class: className, style }) => {
         <ElmButton
           block
           isLoading={currentAnki.value == null || currentAnki.value.loading}
-          onClick$={() =>
-            ankiStore.fetchAnkiBlock(
-              ankiStore,
-              currentAnki.value?.metadata.page_id,
-            )
-          }
+          onClick$={() => fetchBlock(currentAnki.value?.metadata.page_id)}
         >
           <ElmMdiIcon d={mdiRefresh} />
         </ElmButton>

--- a/packages/web-qwik/src/routes/icon/index.tsx
+++ b/packages/web-qwik/src/routes/icon/index.tsx
@@ -11,7 +11,7 @@ import {
 
 import styles from "./icon.module.css";
 import { ElmInlineText, ElmTextField, useAsyncState } from "@elmethis/qwik";
-import { AuthContext } from "~/context/auth-context";
+import { AuthContext, useAuthActions } from "~/context/auth-context";
 import { openApiClient } from "~/openapi/client";
 import { IconCell } from "~/components/icon/icon-cell";
 
@@ -29,12 +29,13 @@ type Icon =
 
 export default component$<IndexProps>(({ class: className, style }) => {
   const authStore = useContext(AuthContext);
+  const { refresh } = useAuthActions();
   const searchKeyword = useSignal<string>("");
   const fuseInstance = useSignal<NoSerialize<Fuse<Icon>> | null>(null);
 
   const { state } = useAsyncState(
     $(async () => {
-      await authStore.tokens.refresh(authStore);
+      await refresh();
 
       const res = await openApiClient.GET("/api/v1/icon", {
         params: {

--- a/packages/web-qwik/src/routes/layout.tsx
+++ b/packages/web-qwik/src/routes/layout.tsx
@@ -12,7 +12,11 @@ import {
 import { Header } from "~/components/common/header";
 
 import { useAnkiContextProvider } from "~/context/anki-context";
-import { AuthContext, useAuthEffect } from "~/context/auth-context";
+import {
+  AuthContext,
+  useAuthActions,
+  useAuthEffect,
+} from "~/context/auth-context";
 
 import styles from "./root-layout.module.css";
 import { useModal } from "@elmethis/qwik";
@@ -26,13 +30,14 @@ export default component$(() => {
   useAuthEffect();
   useAnkiContextProvider();
   const authStore = useContext(AuthContext);
+  const { signIn, signOut } = useAuthActions();
 
   const navigate = useNavigate();
 
   const { Modal, show } = useModal({});
 
   const onSubmit$ = $(async (username: string, password: string) => {
-    await authStore.signIn(authStore, username, password);
+    await signIn(username, password);
   });
 
   return (
@@ -83,7 +88,7 @@ export default component$(() => {
           },
         ]}
         state={authStore.sessionState}
-        handleSignOutClick$={$(async () => authStore.signOut(authStore))}
+        handleSignOutClick$={$(async () => signOut())}
         handleSignInClick$={$(async () => show())}
       />
 

--- a/packages/web-qwik/src/routes/trivia/index.tsx
+++ b/packages/web-qwik/src/routes/trivia/index.tsx
@@ -23,7 +23,7 @@ import { mdiArrowRightThick, mdiEye, mdiLightbulbOnOutline } from "@mdi/js";
 
 import { openApiClient } from "~/openapi/client";
 import { paths } from "~/openapi/schema";
-import { AuthContext } from "~/context/auth-context";
+import { AuthContext, useAuthActions } from "~/context/auth-context";
 
 type TriviaMeta =
   paths["/api/v1/trivia"]["get"]["responses"]["200"]["content"]["application/json"][number];
@@ -56,6 +56,7 @@ export interface IndexProps {
 
 export default component$<IndexProps>(({ class: className, style }) => {
   const authStore = useContext(AuthContext);
+  const { refresh } = useAuthActions();
 
   const store = useStore<TriviaStore>({
     data: [],
@@ -87,7 +88,7 @@ export default component$<IndexProps>(({ class: className, style }) => {
   const fetchList = $(async (append: boolean, signal?: AbortSignal) => {
     store.loading = true;
     try {
-      await authStore.tokens.refresh(authStore);
+      await refresh();
 
       const { data } = await openApiClient.GET("/api/v1/trivia", {
         params: {
@@ -138,7 +139,7 @@ export default component$<IndexProps>(({ class: className, style }) => {
       if (item.loading || item.block) return;
 
       await patchItem(pageId, { loading: true });
-      await authStore.tokens.refresh(authStore);
+      await refresh();
 
       const { data } = await openApiClient.GET(
         "/api/v1/trivia/block/{page_id}",
@@ -169,7 +170,7 @@ export default component$<IndexProps>(({ class: className, style }) => {
     store.viewed.push(pageId);
 
     try {
-      await authStore.tokens.refresh(authStore);
+      await refresh();
       const { data } = await openApiClient.POST(
         "/api/v1/trivia/{page_id}/view",
         {


### PR DESCRIPTION
## Summary

Refactors the global state management in `packages/web-qwik` so context stores hold **serializable data only**, with behavior moved into `useAuthActions()` / `useAnkiActions()` hooks that read the store(s) from context.

- Removes the `store.method(store, …)` **self-passing** pattern from every consumer (`layout`, `anki`, `todo`, `trivia`, `icon`).
- Token `refresh` is now **single-flight** — concurrent callers share one in-flight `fetchAuthSession` via a `noSerialize` promise slot, replacing the busy-wait `while (tokens.loading) sleep(200)` mutex in the auth bootstrap. This also fixes the cold-load race between the bootstrap and the Anki prefetch.
- Establishes one convention: global context = serializable data + action hook; feature-local state stays in the container.

## Behavior notes

- `signIn` now **awaits** `refresh()` (was fire-and-forget) — the modal stays loading until the token resolves.
- The optimistic `PUT` in `updateByRating` keeps its fire-and-forget semantics, now via `void` instead of an IIFE.

## Verification

- `tsc --noEmit` ✓
- `eslint` ✓
- `qwik build` (client + SSR + SSG prerender of all routes) ✓
- Manual browser smoke test (sign in/out, protected fetches, Anki prefetch) ✓

## Follow-up (not in this PR)

Phase 3 — migrate the render-data fetches (todo / bookmark / anki list) from `useVisibleTask$` + manual loading flags to `useAsync$` + `<Suspense>`. Held separately because it restructures the optimistic-update flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)