### PR TITLE
feat(pixai-webhook-worker): add Notion Worker for PixAI task webhooks

### DIFF
--- a/packages/pixai-webhook-worker/.gitignore
+++ b/packages/pixai-webhook-worker/.gitignore
@@ -1,0 +1,6 @@
+.env
+.env.*
+dist/
+node_modules/
+workers.*.json
+workers.json

--- a/packages/pixai-webhook-worker/README.md
+++ b/packages/pixai-webhook-worker/README.md
@@ -1,0 +1,73 @@
+# pixai-webhook-worker
+
+A [Notion Worker](https://developers.notion.com/workers/get-started/overview) that
+receives [PixAI task webhooks](https://platform.pixai.art/en/docs/references/webhook)
+and upserts one page per PixAI task in a Notion database (status + generated media
+URLs).
+
+## How it works
+
+PixAI POSTs `{ action: "task_*", data: { id, status, ..., outputs: { mediaUrls } } }`
+to the worker's webhook URL whenever a task starts, completes, is canceled, or fails.
+The `onPixaiTask` handler:
+
+1. Validates the payload shape (PixAI sends no signature; malformed requests are
+   rejected with `WebhookVerificationError`, which suppresses retries).
+2. Looks up an existing page by the `Task ID` property.
+3. Updates it, or creates a new page if none exists. Media URLs are written to the
+   `Media` files property when the task completes.
+
+## Notion database schema
+
+Create a database and give your integration access to it. Required properties:
+
+| Property  | Type      |
+| --------- | --------- |
+| `Name`    | Title     |
+| `Task ID` | Rich text |
+| `Status`  | Select    |
+| `Updated` | Date      |
+| `Media`   | Files     |
+| `URL`     | URL       |
+
+## Setup
+
+1. Install the Notion CLI (interactive; run it yourself):
+
+   ```sh
+   curl -fsSL https://ntn.dev | bash
+   ```
+
+2. Set secrets (webhooks require your own Notion token — a personal access token or
+   an internal integration token that has been connected to the database):
+
+   ```sh
+   ntn workers env set NOTION_API_TOKEN=ntn_xxx
+   ntn workers env set PIXAI_DATABASE_ID=<database-id>
+   ntn workers env set PIXAI_API_KEY=<pixai-api-key>
+   ```
+
+   `PIXAI_API_KEY` (from [My API Keys](https://platform.pixai.art/en/docs/quick-start/enroll-in-api))
+   is used to resolve the media IDs in completed-task events to downloadable
+   URLs via `GET https://api.pixai.art/v1/media/{mediaId}`.
+
+3. Deploy and get the webhook URL:
+
+   ```sh
+   ntn workers deploy
+   ntn workers webhooks list
+   ```
+
+4. Register the printed URL on your
+   [PixAI profile page](https://platform.pixai.art/en/docs/references/webhook)
+   (or pass it as `callbackUrl` per task in the PixAI REST API).
+
+   The URL contains an unguessable ID and acts as a shared secret — treat it as
+   sensitive.
+
+## Debugging
+
+```sh
+ntn workers runs list
+ntn workers runs logs <run-id>
+```

--- a/packages/pixai-webhook-worker/package.json
+++ b/packages/pixai-webhook-worker/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "pixai-webhook-worker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Notion Worker that receives PixAI task webhooks and upserts pages in a Notion database",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.9.2"
+  },
+  "dependencies": {
+    "@notionhq/workers": "^0.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/pixai-webhook-worker/src/index.ts
+++ b/packages/pixai-webhook-worker/src/index.ts
@@ -1,0 +1,186 @@
+import { Worker, WebhookVerificationError } from "@notionhq/workers";
+
+const worker = new Worker();
+export default worker;
+
+/**
+ * PixAI task webhook payload.
+ * https://platform.pixai.art/en/docs/references/webhook
+ *
+ * PixAI sends no signature header; the unguessable Notion webhook URL is the
+ * only transport-level auth, so the payload shape is validated strictly and
+ * anything unexpected is rejected without retries.
+ */
+interface PixaiOutputs {
+  mediaIds?: string[];
+  mediaUrls?: string[];
+  mediaId?: string;
+  videos?: Array<{ mediaId?: string; thumbnailMediaId?: string }>;
+}
+
+interface PixaiTaskEvent {
+  action: string;
+  data: {
+    id: string;
+    status: string;
+    createdAt?: string;
+    updatedAt?: string;
+    outputs?: PixaiOutputs;
+  };
+}
+
+function parsePixaiEvent(body: Record<string, unknown>): PixaiTaskEvent {
+  // Webhooks configured on the profile page send the event name as `type`;
+  // the documented `callbackUrl` format uses `action`. Same `data` shape.
+  const action = body["type"] ?? body["action"];
+  const data = body["data"] as PixaiTaskEvent["data"] | undefined;
+
+  if (
+    typeof action !== "string" ||
+    !action.startsWith("task_") ||
+    typeof data?.id !== "string" ||
+    typeof data?.status !== "string"
+  ) {
+    throw new WebhookVerificationError(
+      `Request body does not match the PixAI task event shape: ${JSON.stringify(body).slice(0, 1000)}`,
+    );
+  }
+
+  return { action, data };
+}
+
+function collectMediaIds(outputs: PixaiOutputs | undefined): string[] {
+  if (!outputs) return [];
+  const ids = [...(outputs.mediaIds ?? [])];
+  for (const video of outputs.videos ?? []) {
+    if (video.mediaId) ids.push(video.mediaId);
+    if (video.thumbnailMediaId) ids.push(video.thumbnailMediaId);
+  }
+  if (outputs.mediaId) ids.push(outputs.mediaId);
+  return [...new Set(ids)];
+}
+
+/** Resolve a PixAI media ID to a downloadable URL via GET /v1/media/{id}. */
+async function resolveMediaUrl(
+  mediaId: string,
+  apiKey: string,
+): Promise<{ name: string; url: string } | null> {
+  const res = await fetch(`https://api.pixai.art/v1/media/${mediaId}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    console.error(`Failed to resolve media ${mediaId}: HTTP ${res.status}`);
+    return null;
+  }
+  const media = (await res.json()) as {
+    type?: string;
+    urls?: Array<{ variant?: string; url?: string }>;
+  };
+  const url = media.urls?.find((entry) => entry.url)?.url;
+  if (!url) {
+    console.error(`Media ${mediaId} has no URL: ${JSON.stringify(media)}`);
+    return null;
+  }
+  return { name: `${media.type?.toLowerCase() ?? "media"}-${mediaId}`, url };
+}
+
+worker.webhook("onPixaiTask", {
+  title: "PixAI Task Webhook",
+  description:
+    "Upserts one Notion page per PixAI task, tracking status and generated media URLs.",
+  execute: async (events, { notion }) => {
+    const databaseId = process.env.PIXAI_DATABASE_ID;
+    if (!databaseId) {
+      throw new Error(
+        "PIXAI_DATABASE_ID is not set. Run: ntn workers env set PIXAI_DATABASE_ID=<database-id>",
+      );
+    }
+
+    // API version 2025-09-03: pages are queried per data source, not per
+    // database. Single-source databases (the normal case) have exactly one.
+    const database = await notion.databases.retrieve({
+      database_id: databaseId,
+    });
+    const dataSourceId =
+      "data_sources" in database ? database.data_sources[0]?.id : undefined;
+    if (!dataSourceId) {
+      throw new Error(`Database ${databaseId} has no data source`);
+    }
+
+    for (const event of events) {
+      const { action, data } = parsePixaiEvent(event.body);
+
+      const existing = await notion.dataSources.query({
+        data_source_id: dataSourceId,
+        filter: { property: "Task ID", rich_text: { equals: data.id } },
+        page_size: 1,
+      });
+
+      console.log(
+        `Task ${data.id} (${action}) outputs: ${JSON.stringify(data.outputs)?.slice(0, 2000)}`,
+      );
+      // Prefer URLs sent inline; profile-page webhooks only send media IDs,
+      // which need a PixAI API call to resolve.
+      const mediaFiles = (data.outputs?.mediaUrls ?? []).map((url, i) => ({
+        name: `media-${i + 1}`,
+        url,
+      }));
+      if (mediaFiles.length === 0) {
+        const mediaIds = collectMediaIds(data.outputs);
+        const apiKey = process.env.PIXAI_API_KEY;
+        if (mediaIds.length > 0 && !apiKey) {
+          console.error(
+            "PIXAI_API_KEY is not set; cannot resolve media IDs to URLs. Run: ntn workers env set PIXAI_API_KEY=<api-key>",
+          );
+        } else if (mediaIds.length > 0 && apiKey) {
+          const resolved = await Promise.all(
+            mediaIds.map((id) => resolveMediaUrl(id, apiKey)),
+          );
+          mediaFiles.push(...resolved.filter((file) => file !== null));
+        }
+      }
+
+      const properties: Parameters<
+        typeof notion.pages.update
+      >[0]["properties"] = {
+        Status: { select: { name: data.status } },
+        URL: {
+          url: `https://pixai.art/en/generator/?taskId=${data.id}&showOnStage=1`,
+        },
+      };
+      if (data.updatedAt) {
+        properties["Updated"] = { date: { start: data.updatedAt } };
+      }
+      if (mediaFiles.length > 0) {
+        properties["Media"] = {
+          files: mediaFiles.map((file) => ({
+            name: file.name,
+            external: { url: file.url },
+          })),
+        };
+      }
+
+      if (existing.results.length > 0) {
+        await notion.pages.update({
+          page_id: existing.results[0].id,
+          properties,
+        });
+      } else {
+        await notion.pages.create({
+          parent: { database_id: databaseId },
+          properties: {
+            Name: {
+              title: [{ text: { content: `PixAI task ${data.id}` } }],
+            },
+            "Task ID": { rich_text: [{ text: { content: data.id } }] },
+            ...properties,
+          },
+        });
+      }
+
+      console.log(
+        `Processed ${action} for task ${data.id} (delivery ${event.deliveryId})`,
+      );
+    }
+  },
+});

--- a/packages/pixai-webhook-worker/tsconfig.json
+++ b/packages/pixai-webhook-worker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,19 @@ importers:
         specifier: ^0.22.1
         version: 0.22.1
 
+  packages/pixai-webhook-worker:
+    dependencies:
+      '@notionhq/workers':
+        specifier: ^0.4.0
+        version: 0.4.0(@notionhq/client@5.22.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.2
+      typescript:
+        specifier: ^5.8.0
+        version: 5.8.3
+
   packages/web-qwik:
     devDependencies:
       '@elmethis/core':
@@ -963,6 +976,16 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@notionhq/client@5.22.0':
+    resolution: {integrity: sha512-lZ3JGBCd6O6MNHWn/58QcUqX1FgmlcODcx/EaUEEpuxLXF5tSi+v29Vzoz8mZ6JgDWDn5pMzzjB69QevYjQQZA==}
+    engines: {node: '>=18'}
+
+  '@notionhq/workers@0.4.0':
+    resolution: {integrity: sha512-+FgL9Xa6qS4EsIN9gVtfwt1rssfk9NIwx7tMS3d4b5Z6Kb5MRFgKLWllav2XCc2Lk94+h05+MvwgOcwgTPJfuw==}
+    engines: {node: '>=22.0.0', npm: '>=10.9.2'}
+    peerDependencies:
+      '@notionhq/client': '>=2.2.15'
 
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
@@ -1966,6 +1989,9 @@ packages:
 
   '@types/node@20.19.0':
     resolution: {integrity: sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==}
+
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/postcss-modules-local-by-default@4.0.2':
     resolution: {integrity: sha512-CtYCcD+L+trB3reJPny+bKWKMzPfxEyQpKIwit7kErnOexf5/faaGpkFy4I5AwbV4hp1sk7/aTg0tt0B67VkLQ==}
@@ -4350,6 +4376,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   undici@8.5.0:
     resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
@@ -5698,6 +5727,14 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@notionhq/client@5.22.0': {}
+
+  '@notionhq/workers@0.4.0(@notionhq/client@5.22.0)':
+    dependencies:
+      '@notionhq/client': 5.22.0
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     optional: true
 
@@ -6683,6 +6720,10 @@ snapshots:
   '@types/node@20.19.0':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@24.13.2':
+    dependencies:
+      undici-types: 7.18.2
 
   '@types/postcss-modules-local-by-default@4.0.2':
     dependencies:
@@ -9871,6 +9912,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici-types@7.18.2: {}
 
   undici@8.5.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/web-qwik"
+  - "packages/pixai-webhook-worker"


### PR DESCRIPTION
Receives PixAI task webhooks and upserts one page per task in a Notion database: status, permalink, and generated media resolved from media IDs via the PixAI API.