### PR TITLE
feat(to-do): filter Notion to-do list by Type "To Do"

### DIFF
--- a/crates/http-api-to-do/src/use_case/mod.rs
+++ b/crates/http-api-to-do/src/use_case/mod.rs
@@ -145,6 +145,11 @@ impl ToDoUseCase {
                 PageProperty::Title(PageTitleProperty::from(title.clone())),
             );
 
+            properties.insert(
+                "Type".to_string(),
+                PageProperty::Select(PageSelectProperty::from("To Do")),
+            );
+
             if let Some(deadline) = deadline {
                 properties.insert(
                     "Deadline".to_string(),
@@ -217,6 +222,7 @@ impl ToDoUseCase {
     pub async fn list_notion_to_do(&self) -> Result<Vec<ToDoEntity>, ToDoUseCaseError> {
         let filter = notionrs_types::object::request::filter::Filter::and(vec![
             notionrs_types::object::request::filter::Filter::checkbox_is_not_checked("IsArchived"),
+            notionrs_types::object::request::filter::Filter::select_equals("Type", "To Do"),
         ]);
 
         let response = self.to_do_repository.list_notion_to_do(filter).await?;


### PR DESCRIPTION
## Summary

The Notion To Do database gained a **Type** select property with variants `To Do` / `Schedule` / `Diary`. This PR makes the API deal only with the `To Do` variant:

- `list_notion_to_do` adds `Filter::select_equals("Type", "To Do")` alongside the existing `IsArchived` filter, so Schedule and Diary pages are excluded.
- `create_to_do` sets `Type = "To Do"` on new pages so items created through the app remain visible in the filtered list.

## Testing

- `cargo clippy -p http-api-to-do --all-targets` clean
- `cargo test -p http-api-to-do` — 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)